### PR TITLE
Use `python3.11` in automated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     name: Python Linux ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     name: Python Windows ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
In the long term, we should also support this version. However, we do not have to merge this PR directly yet, but we can wait until we have merged most of the PRs from the old repo. 