### PR TITLE
Adjust parsing of major version number to account for development builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,12 @@ Do not use this command during a search!
 ### Get current major version of stockfish engine
 E.g., if the engine being used is Stockfish 14.1 or Stockfish 14, then the function would return 14.
 Meanwhile, if a development build of the engine is being used (not an official release), then the function returns an 
-int with 5 or 6 digits, representing the date the engine was compiled on. 
-For example, 20122 is returned for the development build compiled on January 2, 2022.
+int, representing the date the engine was compiled on. There were two different versioning systems.
+Either it is a 5 or 6 digit long number with *ddmmyy* or an 8 digit long with *yyyymmdd*.
+For example, 20122 is returned for the development build compiled on January 2, 2022 and 20230329 is for the build on March 29, 2023.
+
+A return value of -1 from this function means that something did not work when parsing the version number.
+If this happens to you, please open an issue and specify which release you used so we can fix the problem.
 ```python 
 stockfish.get_stockfish_major_version()
 ```

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -57,8 +57,8 @@ class Stockfish:
 
         self._has_quit_command_been_sent = False
 
-        self._stockfish_major_version: int = int(
-            self._read_line().split(" ")[1].split(".")[0].replace("-", "")
+        self._stockfish_major_version: int = self._extract_major_version(
+            self._read_line()
         )
 
         self._put("uci")
@@ -140,6 +140,23 @@ class Stockfish:
             None
         """
         self.update_engine_parameters(self._DEFAULT_STOCKFISH_PARAMS)
+
+    def _extract_major_version(self, output_line: str) -> int:
+        # To prevent the wrapper from not working at all,
+        # -1 is used as version number in case of problems
+        try:
+            version_specifier = output_line.split(" ")[1]
+            # Case: dev-20230329-3f01e3f4
+            if "dev" in version_specifier:
+                return int(version_specifier.split("-")[1])
+            # Case: 15.1
+            if "." in version_specifier:
+                return int(version_specifier.split(".")[0].replace("-", ""))
+            # Case: 200222
+            return int(version_specifier.replace("-", ""))
+
+        except ValueError:
+            return -1
 
     def _prepare_for_new_position(self, send_ucinewgame_token: bool = True) -> None:
         if send_ucinewgame_token:
@@ -750,7 +767,7 @@ class Stockfish:
         """
         return (
             self._stockfish_major_version >= 10109
-            and self._stockfish_major_version <= 311299
+            and self._stockfish_major_version <= 29991231
         )
 
     def send_quit_command(self) -> None:

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -938,3 +938,15 @@ class TestStockfish:
         stockfish.__del__()
         assert stockfish._stockfish.poll() is not None
         assert Stockfish._del_counter == old_del_counter + 1
+
+    @pytest.mark.parametrize(
+        "line,expected",
+        [
+            ("Stockfish 15.1 by", 15),
+            ("Stockfish 200222 by", 200222),
+            ("Stockfish dev-20230329-3f01e3f4 by", 20230329),
+            ("Stockfish dev-15.1", -1),
+        ],
+    )
+    def test_version_number_extraction(self, stockfish, line, expected):
+        assert expected == stockfish._extract_major_version(line)


### PR DESCRIPTION
Closes #11 

The version numbering system for development builds has been changed. Previous development builds had their release date as version number (like `200222`) but the system was changed and now they contain more information (like `dev-20230329-3f01e3f4`). The parser is not able to understand that version number and fails.

This PR solves that problem and implements a try/catch for unrecognized version numbers.