### PR TITLE
Add support for 'go nodes' in get_top_moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,15 @@ True
 
 ### Get info on the top n moves
 ```python
-stockfish.get_top_moves(3)
+stockfish.get_top_moves(3, num_nodes=0)
+```
+Optional parameter "num_nodes" specifies the number of nodes to search. If num_nodes is 0, then the engine will search until it finds the top n moves.
+```text
+[
+    {'Move': 'd2d4', 'Centipawn': 0, 'Mate': None},
+    {'Move': 'd2d3', 'Centipawn': 0, 'Mate': None},
+    {'Move': 'g1f3', 'Centipawn': 0, 'Mate': None}
+]
 ```
 ```text
 [

--- a/README.md
+++ b/README.md
@@ -133,13 +133,7 @@ True
 stockfish.get_top_moves(3, num_nodes=0)
 ```
 Optional parameter "num_nodes" specifies the number of nodes to search. If num_nodes is 0, then the engine will search until it finds the top n moves.
-```text
-[
-    {'Move': 'd2d4', 'Centipawn': 0, 'Mate': None},
-    {'Move': 'd2d3', 'Centipawn': 0, 'Mate': None},
-    {'Move': 'g1f3', 'Centipawn': 0, 'Mate': None}
-]
-```
+
 ```text
 [
     {'Move': 'f5h7', 'Centipawn': None, 'Mate': 1},

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -523,7 +523,7 @@ class Stockfish:
         Args:
             num_top_moves:
                 The number of moves to return info on, assuming there are at least
-                those many legal moves.
+                that many legal moves.
 
             num_nodes:
                 The number of nodes/positions that stockfish searches in the game tree.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -584,6 +584,8 @@ class Stockfish:
                             else None,
                         },
                     )
+                elif len(top_moves) >= num_top_moves:
+                    break
             else:
                 break
         if old_MultiPV_value != self._parameters["MultiPV"]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -525,6 +525,9 @@ class Stockfish:
                 The number of moves to return info on, assuming there are at least
                 those many legal moves.
 
+            num_nodes:
+                The number of nodes/positions that stockfish searches in the game tree.
+
         Returns:
             A list of dictionaries. In each dictionary, there are keys for Move, Centipawn, and Mate;
             the corresponding value for either the Centipawn or Mate key will be None.
@@ -538,7 +541,7 @@ class Stockfish:
             self._set_option("MultiPV", num_top_moves)
             self._parameters.update({"MultiPV": num_top_moves})
 
-        self._go() if not num_nodes > 0 else self._go_nodes(num_nodes)
+        self._go() if num_nodes == 0 else self._go_nodes(num_nodes)
 
         lines = []
         while True:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -522,15 +522,15 @@ class Stockfish:
 
         Args:
             num_top_moves:
-                The number of moves to return info on, assuming there are at least
-                that many legal moves.
+                The number of moves for which to return information, assuming there
+                are at least that many legal moves.
 
             num_nodes:
-                The number of nodes/positions that stockfish searches in the game tree.
+                The number of nodes/positions that Stockfish searches in the game tree.
 
         Returns:
-            A list of dictionaries. In each dictionary, there are keys for Move, Centipawn, and Mate;
-            the corresponding value for either the Centipawn or Mate key will be None.
+            A list of dictionaries, where each dictionary contains keys for Move, Centipawn,
+            and Mate. The corresponding value for either the Centipawn or Mate key will be None.
             If there are no moves in the position, an empty list is returned.
         """
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -571,6 +571,20 @@ class TestStockfish:
         assert stockfish.get_top_moves() == []
         assert stockfish.get_parameters()["MultiPV"] == 3
 
+    def test_get_top_moves_by_nodes(self, stockfish):
+        stockfish.set_depth(15)
+        stockfish._set_option("MultiPV", 4)
+        stockfish.set_fen_position("1rQ1r1k1/5ppp/8/8/1R6/8/2r2PPP/4R1K1 w - - 0 1")
+        assert stockfish.get_top_moves(2, num_nodes=15000000) == [
+            {"Move": "e1e8", "Centipawn": None, "Mate": 1},
+            {"Move": "c8e8", "Centipawn": None, "Mate": 2},
+        ]
+        stockfish.set_fen_position("8/8/8/8/8/3r2k1/8/6K1 w - - 0 1")
+        assert stockfish.get_top_moves(2, num_nodes=15000000) == [
+            {"Move": "g1f1", "Centipawn": None, "Mate": -2},
+            {"Move": "g1h1", "Centipawn": None, "Mate": -1},
+        ]
+
     def test_get_top_moves_raising_error(self, stockfish):
         stockfish.set_fen_position(
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"


### PR DESCRIPTION
Add support for UCI command `go nodes <num_nodes>`. 

This is useful for determining top moves without using `depth`,  as some searches using depth can get very large in terms of nodes, without much added value. (Especially in positions with forced moves.)

Example use-case: https://github.com/knutole/catchfish 🐳 