### PR TITLE
Add include_info=True flag to .get_top_moves()

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ True
 
 ### Get info on the top n moves
 ```python
-stockfish.get_top_moves(3)
+stockfish.get_top_moves(3, include_info=False)
 ```
+Optional parameter `include_info` specifies whether to include the full info from the engine in the returned dictionary, including seldepth, multipv, time, nodes, nps, and wdl if available. Boolean. Default is `False`.
 ```text
 [
     {'Move': 'f5h7', 'Centipawn': None, 'Mate': 1},

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -514,7 +514,9 @@ class Stockfish:
             elif splitted_text[0] == "bestmove":
                 return evaluation
 
-    def get_top_moves(self, num_top_moves: int = 5) -> List[dict]:
+    def get_top_moves(
+        self, num_top_moves: int = 5, include_info: bool = False
+    ) -> List[dict]:
         """Returns info on the top moves in the position.
 
         Args:
@@ -522,10 +524,18 @@ class Stockfish:
                 The number of moves to return info on, assuming there are at least
                 those many legal moves.
 
+            include_info:
+                Option to include the full info from the engine in the returned dictionary,
+                including seldepth, multipv, time, nodes, nps, and wdl if available.
+                Boolean. Default is False.
+
         Returns:
             A list of dictionaries. In each dictionary, there are keys for Move, Centipawn, and Mate;
             the corresponding value for either the Centipawn or Mate key will be None.
             If there are no moves in the position, an empty list is returned.
+
+            If include_info is True, the dictionary will also include the keys SelectiveDepth, Time,
+            Nodes, N/s, MultiPVLine, and WDL (if available). WDL is set from the White player's perspective.
         """
 
         if num_top_moves <= 0:
@@ -562,20 +572,44 @@ class Stockfish:
                         raise RuntimeError(
                             "Having a centipawn value and mate value should be mutually exclusive."
                         )
-                    top_moves.insert(
-                        0,
-                        {
-                            "Move": current_line[current_line.index("pv") + 1],
-                            "Centipawn": int(current_line[current_line.index("cp") + 1])
-                            * multiplier
-                            if has_centipawn_value
-                            else None,
-                            "Mate": int(current_line[current_line.index("mate") + 1])
-                            * multiplier
-                            if has_mate_value
-                            else None,
-                        },
-                    )
+                    move_evaluation = {
+                        "Move": current_line[current_line.index("pv") + 1],
+                        "Centipawn": int(current_line[current_line.index("cp") + 1])
+                        * multiplier
+                        if has_centipawn_value
+                        else None,
+                        "Mate": int(current_line[current_line.index("mate") + 1])
+                        * multiplier
+                        if has_mate_value
+                        else None,
+                    }
+                    if include_info == True:
+                        move_evaluation.update(
+                            {
+                                "Nodes": current_line[current_line.index("nodes") + 1],
+                                "N/s": current_line[current_line.index("nps") + 1],
+                                "Time": current_line[current_line.index("time") + 1],
+                                "SelectiveDepth": current_line[
+                                    current_line.index("seldepth") + 1
+                                ],
+                                "MultiPVLine": current_line[
+                                    current_line.index("multipv") + 1
+                                ],
+                            }
+                        )
+                        if self.does_current_engine_version_have_wdl_option():
+                            move_evaluation.update(
+                                {
+                                    "WDL": " ".join(
+                                        [
+                                            current_line[current_line.index("wdl") + 1],
+                                            current_line[current_line.index("wdl") + 2],
+                                            current_line[current_line.index("wdl") + 3],
+                                        ][::multiplier]
+                                    )
+                                }
+                            )
+                    top_moves.insert(0, move_evaluation)
             else:
                 break
         if old_MultiPV_value != self._parameters["MultiPV"]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -583,7 +583,7 @@ class Stockfish:
                         if has_mate_value
                         else None,
                     }
-                    if include_info == True:
+                    if include_info:
                         move_evaluation.update(
                             {
                                 "Nodes": current_line[current_line.index("nodes") + 1],

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -571,6 +571,31 @@ class TestStockfish:
         assert stockfish.get_top_moves() == []
         assert stockfish.get_parameters()["MultiPV"] == 3
 
+    def test_get_top_moves_with_info(self, stockfish):
+        stockfish.set_depth(15)
+        stockfish._set_option("MultiPV", 4)
+        stockfish.set_fen_position("1rQ1r1k1/5ppp/8/8/1R6/8/2r2PPP/4R1K1 w - - 0 1")
+        assert stockfish.get_top_moves(2, include_info=False) == [
+            {"Move": "e1e8", "Centipawn": None, "Mate": 1},
+            {"Move": "c8e8", "Centipawn": None, "Mate": 2},
+        ]
+        moves = stockfish.get_top_moves(2, include_info=True)
+        assert all(
+            k in moves[0]
+            for k in (
+                "Move",
+                "Centipawn",
+                "Mate",
+                "MultiPVLine",
+                "N/s",
+                "Nodes",
+                "SelectiveDepth",
+                "Time",
+            )
+        )
+        if stockfish.does_current_engine_version_have_wdl_option():
+            assert "WDL" in moves[0]
+
     def test_get_top_moves_raising_error(self, stockfish):
         stockfish.set_fen_position(
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"


### PR DESCRIPTION
In certain use-cases it is nice to get more information from `.get_top_moves()`, like WDL, selective depth, nodes, etc. 

One use-case for this is when evaluating full games. If you want both top moves for n lines, and the WDL, you'd have to run the evaluation multiple times. Also, there is currently no way of getting info like nodes, time, nps, etc. 

```py
# unchanged 
moves = stockfish.get_top_moves(2)
print(moves)
# [
#   {   
#     'Centipawn': None,
#     'Mate': 1,
#     'Move': 'e1e8'
#   },
#   {
#     'Centipawn': None,
#     'Mate': 2,
#     'Move': 'c8e8'
#   }
# ]

# unchanged
moves = stockfish.get_top_moves(2, include_info=False)
print(moves)
# [
#   {   
#     'Centipawn': None,
#     'Mate': 1,
#     'Move': 'e1e8'
#   },
#   {
#     'Centipawn': None,
#     'Mate': 2,
#     'Move': 'c8e8'
#   }
# ]

# returns more info
moves = stockfish.get_top_moves(2, include_info=True)
print(moves)
# [
#   {   
#     'Centipawn': None,
#     'Mate': 1,
#     'Move': 'e1e8',
#     'MultiPVLine': '1',
#     'N/s': '10255014',
#     'Nodes': '5096742',
#     'SelectiveDepth': '2',
#     'Time': '497',
#     'WDL': '1000 0 0'
#   },
#   {
#     'Centipawn': None,
#     'Mate': 2,
#     'Move': 'c8e8',
#     'MultiPVLine': '2',
#     'N/s': '10255014',
#     'Nodes': '5096742',
#     'SelectiveDepth': '4',
#     'Time': '497',
#     'WDL': '1000 0 0'
#   }
# ]

```

Example use-case: https://github.com/knutole/catchfish 🐳 