### PR TITLE
Refactor and add `num_nodes` and `verbose` options to `get_top_moves()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Optional parameter `num_nodes` specifies the number of nodes to search. If num_n
 ### Set perspective of the evaluation
 You can set the perspective of the evaluation to be from the perspective of the side to move, or from the perspective of White.
 ```py
-# Set perspective to be from the perspective of the side to move
+# Set the perspective of the evaluation to be from the point of view of the side to move
 stockfish.is_turn_perspective(True)
 
-# Set perspective to be from the perspective of White
+# Set the perspective of the evaluation to be from White's perspective
 stockfish.is_turn_perspective(False)
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,20 @@
 
 Implements an easy-to-use Stockfish class to integrates the Stockfish chess engine with Python.
 
-
-
 ## Install
+
 ```bash
 $ pip install stockfish
 ```
 
 #### Ubuntu
+
 ```bash
 $ sudo apt install stockfish
-``` 
+```
 
 #### Mac OS
+
 ```bash
 $ brew install stockfish
 ```
@@ -35,6 +36,7 @@ stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64")
 ```
 
 There are some default engine settings used by this wrapper. For increasing Stockfish's strength and speed, the "Threads" and "Hash" parameters can be modified.
+
 ```python
 {
     "Debug Log File": "",
@@ -55,86 +57,109 @@ There are some default engine settings used by this wrapper. For increasing Stoc
 ```
 
 You can change them, as well as the default search depth, during your Stockfish class initialization:
+
 ```python
 stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64", depth=18, parameters={"Threads": 2, "Minimum Thinking Time": 30})
 ```
 
 These parameters can also be updated at any time by calling the "update_engine_parameters" function:
+
 ```python
 stockfish.update_engine_parameters({"Hash": 2048, "UCI_Chess960": "true"}) # Gets stockfish to use a 2GB hash table, and also to play Chess960.
 ```
 
 When you're done using the Stockfish engine process, you can send the "quit" uci command to it with:
+
 ```python
 stockfish.send_quit_command()
 ```
+
 The `__del__()` method of the Stockfish class will call send_quit_command(), but it's technically not guaranteed python will call `__del__()` when the Stockfish object goes out of scope. So even though it'll probably not be needed, it doesn't hurt to call send_quit_command() yourself.
 
 ### Set position by a sequence of moves from the starting position
+
 ```python
 stockfish.set_position(["e2e4", "e7e6"])
 ```
 
 ### Update position by making a sequence of moves from the current position
+
 ```python
 stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1"])
 ```
 
 ### Set position by Forsyth–Edwards Notation (FEN)
+
 If you'd like to first check if your fen is valid, call the is_fen_valid() function below.  
 Also, if you want to play Chess960, it's recommended you first update the "UCI_Chess960" engine parameter to be "true", before calling set_fen_position.
+
 ```python
 stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")
 ```
 
 ### Check whether the given FEN is valid
+
 This function returns a bool saying whether the passed in FEN is valid (both syntax wise and whether the position represented is legal).  
 The function isn't perfect and won't catch all cases, but generally it should return the correct answer.
-For example, one exception is positions which are legal, but have no legal moves. 
+For example, one exception is positions which are legal, but have no legal moves.
 I.e., for checkmates and stalemates, this function will incorrectly say the fen is invalid.
+
 ```python
 stockfish.is_fen_valid("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
 ```
+
 ```text
 True
 ```
+
 ```python
 stockfish.is_fen_valid("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -") # will return False, in this case because the FEN is missing two of the six required fields.
 ```
+
 ```text
 False
 ```
 
 ### Get best move
+
 ```python
 stockfish.get_best_move()
 ```
+
 ```text
 d2d4
 ```
+
 It's possible to specify remaining time on black and/or white clock. Time is in milliseconds.
+
 ```python
 stockfish.get_best_move(wtime=1000, btime=1000)
 ```
 
 ### Get best move based on a time constraint
+
 ```python
 stockfish.get_best_move_time(1000)
 ```
+
 Time constraint is in milliseconds
+
 ```text
 e2e4
 ```
 
 ### Check is move correct with current position
+
 ```python
 stockfish.is_move_correct('a2a3')
 ```
+
 ```text
 True
 ```
 
 ### Get info on the top n moves
+
 Get moves, centipawns, and mates for the top n moves. If the move is a mate, the Centipawn value will be None, and vice versa.
 
 ```python
@@ -145,7 +170,9 @@ stockfish.get_top_moves(3)
 #   {'Move': 'f5h5', 'Centipawn': -31, 'Mate': None}
 # ]
 ```
+
 Optional parameter `verbose` (default `False`) specifies whether to include the full info from the engine in the returned dictionary, including SelectiveDepth, Nodes, NodesPerSecond, Time, MultiPVLine, and WDL if available.
+
 ```py
 stockfish.get_top_moves(1, verbose=True)
 # [{
@@ -160,10 +187,13 @@ stockfish.get_top_moves(1, verbose=True)
 #   "WDL":"0 0 1000"
 # }]
 ```
-Optional parameter `num_nodes` specifies the number of nodes to search. If num_nodes is 0, then the engine will search until it configured depth is reached.
+
+Optional parameter `num_nodes` specifies the number of nodes to search. If num_nodes is 0, then the engine will search until the configured depth is reached.
 
 ### Set perspective of the evaluation
-You can set the perspective of the evaluation to be from the perspective of the side to move, or from the perspective of White.
+
+You can set the perspective of the evaluation to be from the perspective of the side to move, or from the perspective of White. Currently this setting only applies to `get_top_moves()`.
+
 ```py
 # Set the perspective of the evaluation to be from the point of view of the side to move
 stockfish.set_turn_perspective(True)
@@ -176,44 +206,53 @@ is_turn_perspective = stockfish.get_turn_perspective()
 
 ```
 
+### Get Stockfish's win/draw/loss stats for the side to move in the current position
 
-### Get Stockfish's win/draw/loss stats for the side to move in the current position  
 Before calling this function, it is recommended that you first check if your version of Stockfish is recent enough to display WDL stats. To do this,  
 use the "does_current_engine_version_have_wdl_option()" function below.
+
 ```python
 stockfish.get_wdl_stats()
 ```
+
 ```text
 [87, 894, 19]
 ```
 
 ### Find if your version of Stockfish is recent enough to display WDL stats
+
 ```python
 stockfish.does_current_engine_version_have_wdl_option()
 ```
+
 ```text
 True
 ```
 
 ### Set current engine's skill level (ignoring ELO rating)
+
 ```python
 stockfish.set_skill_level(15)
 ```
 
 ### Set current engine's ELO rating (ignoring skill level)
+
 ```python
 stockfish.set_elo_rating(1350)
 ```
 
 ### Set current engine's depth
+
 ```python
 stockfish.set_depth(15)
 ```
 
 ### Get current engine's parameters
+
 ```python
 stockfish.get_parameters()
 ```
+
 ```text
 {
     "Debug Log File": "",
@@ -234,22 +273,27 @@ stockfish.get_parameters()
 ```
 
 ### Reset the engine's parameters to the default
+
 ```python
 stockfish.reset_engine_parameters()
 ```
 
 ### Get current board position in Forsyth–Edwards notation (FEN)
+
 ```python
 stockfish.get_fen_position()
 ```
+
 ```text
 rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
 ```
 
 ### Get current board visual
-```python 
+
+```python
 stockfish.get_board_visual()
 ```
+
 ```text
 +---+---+---+---+---+---+---+---+
 | r | n | b | q | k | b | n | r | 8
@@ -270,10 +314,13 @@ stockfish.get_board_visual()
 +---+---+---+---+---+---+---+---+
   a   b   c   d   e   f   g   h
 ```
+
 This function has an optional boolean (True by default) as a parameter that indicates whether the board should be seen from the view of white. So it is possible to get the board from black's point of view like this:
-```python 
+
+```python
 stockfish.get_board_visual(False)
 ```
+
 ```text
 +---+---+---+---+---+---+---+---+
 | R | N | B | K | Q | B | N | R | 1
@@ -296,10 +343,13 @@ stockfish.get_board_visual(False)
 ```
 
 ### Get current board evaluation in centipawns or mate in x
-```python 
+
+```python
 stockfish.get_evaluation()
 ```
+
 Positive is advantage white, negative is advantage black
+
 ```text
 {"type":"cp", "value":12}
 {"type":"mate", "value":-3}
@@ -308,10 +358,13 @@ Positive is advantage white, negative is advantage black
 ### Run benchmark
 
 #### BenchmarkParameters
+
 ```python
 params = BenchmarkParameters(**kwargs)
 ```
+
 parameters required to run the benchmark function. kwargs can be used to set custom values.
+
 ```text
 ttSize: range(1,128001)
 threads: range(1,513)
@@ -321,38 +374,46 @@ limitType: "depth", "perft", "nodes", "movetime"
 evalType: "mixed", "classical", "NNUE"
 ```
 
-```python 
+```python
 stockfish.benchmark(params)
 ```
+
 This will run the bench command with BenchmarkParameters.
 It is an additional custom non-UCI command, mainly for debugging.
 Do not use this command during a search!
 
 ### Get current major version of stockfish engine
+
 E.g., if the engine being used is Stockfish 14.1 or Stockfish 14, then the function would return 14.
-Meanwhile, if a development build of the engine is being used (not an official release), then the function returns an 
-int with 5 or 6 digits, representing the date the engine was compiled on. 
+Meanwhile, if a development build of the engine is being used (not an official release), then the function returns an
+int with 5 or 6 digits, representing the date the engine was compiled on.
 For example, 20122 is returned for the development build compiled on January 2, 2022.
-```python 
+
+```python
 stockfish.get_stockfish_major_version()
 ```
+
 ```text
 15
 ```
 
 ### Find if the version of Stockfish being used is a development build
+
 ```python
 stockfish.is_development_build_of_engine()
 ```
+
 ```text
 False
 ```
 
 ### Find what is on a certain square
+
 If the square is empty, the None object is returned. Otherwise, one of 12 enum members of a custom  
 Stockfish.Piece enum will be returned. Each of the 12 members of this enum is named in the following pattern:  
-*colour* followed by *underscore* followed by *piece name*, where the colour and piece name are in all caps.  
-For example, say the current position is the starting position:  
+_colour_ followed by _underscore_ followed by _piece name_, where the colour and piece name are in all caps.  
+For example, say the current position is the starting position:
+
 ```python
 stockfish.get_what_is_on_square("e1") # returns Stockfish.Piece.WHITE_KING
 stockfish.get_what_is_on_square("d8") # returns Stockfish.Piece.BLACK_QUEEN
@@ -361,21 +422,24 @@ stockfish.get_what_is_on_square("b5") # returns None
 ```
 
 ### Find if a move will be a capture (and if so, what type of capture)
-The argument must be a string that represents the move, using the notation that Stockfish uses (i.e., the coordinate of the starting square followed by the coordinate of the ending square).   
+
+The argument must be a string that represents the move, using the notation that Stockfish uses (i.e., the coordinate of the starting square followed by the coordinate of the ending square).  
 The function will return one of the following enum members from a custom Stockfish.Capture enum: DIRECT_CAPTURE, EN_PASSANT, or NO_CAPTURE.  
 For example, say the current position is the one after 1.e4 Nf6 2.Nc3 e6 3.e5 d5.
+
 ```python
-stockfish.will_move_be_a_capture("c3d5")  # returns Stockfish.Capture.DIRECT_CAPTURE  
-stockfish.will_move_be_a_capture("e5f6")  # returns Stockfish.Capture.DIRECT_CAPTURE  
-stockfish.will_move_be_a_capture("e5d6")  # returns Stockfish.Capture.EN_PASSANT  
-stockfish.will_move_be_a_capture("f1e2")  # returns Stockfish.Capture.NO_CAPTURE  
+stockfish.will_move_be_a_capture("c3d5")  # returns Stockfish.Capture.DIRECT_CAPTURE
+stockfish.will_move_be_a_capture("e5f6")  # returns Stockfish.Capture.DIRECT_CAPTURE
+stockfish.will_move_be_a_capture("e5d6")  # returns Stockfish.Capture.EN_PASSANT
+stockfish.will_move_be_a_capture("f1e2")  # returns Stockfish.Capture.NO_CAPTURE
 ```
 
 ### StockfishException
 
-The `StockfishException` is a newly defined Exception type. It is thrown when the underlying Stockfish process created by the wrapper crashes. This can happen when an incorrect input like an invalid FEN (for example ```8/8/8/3k4/3K4/8/8/8 w - - 0 1``` with both kings next to each other) is given to Stockfish. \
+The `StockfishException` is a newly defined Exception type. It is thrown when the underlying Stockfish process created by the wrapper crashes. This can happen when an incorrect input like an invalid FEN (for example `8/8/8/3k4/3K4/8/8/8 w - - 0 1` with both kings next to each other) is given to Stockfish. \
 Not all invalid inputs will lead to a `StockfishException`, but only those which cause the Stockfish process to crash. \
 To handle a `StockfishException` when using this library, import the `StockfishException` from the library and use a `try/except`-block:
+
 ```python
 from stockfish import StockfishException
 
@@ -387,11 +451,13 @@ except StockfishException:
 ```
 
 ## Testing
+
 ```bash
 $ python setup.py test
 ```
 
 ## Security
+
 If you discover any security related issues, please report it via the [Private vulnerability reporting](https://github.com/py-stockfish/stockfish/security) instead of using the issue tracker.
 
 ## Status of the project
@@ -405,8 +471,10 @@ The official PyPi releases for the [Stockfish package](https://pypi.org/project/
 Please submit all bug reports and PRs to this repo instead of the old one.
 
 ## Credits
+
 - We want to sincerely thank [Ilya Zhelyabuzhsky](https://github.com/zhelyabuzhsky), the original founder of this project for writing and maintaining the code and for his contributions to the open source community.
 - We also want to thank all the [other contributors](https://github.com/py-stockfish/stockfish/graphs/contributors) for working on this project.
 
 ## License
+
 MIT License. Please see [License File](https://github.com/py-stockfish/stockfish/blob/master/LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ stockfish.get_top_moves(1, verbose=True)
 ```
 Optional parameter `num_nodes` specifies the number of nodes to search. If num_nodes is 0, then the engine will search until it configured depth is reached.
 
+### Set perspective of the evaluation
+You can set the perspective of the evaluation to be from the perspective of the side to move, or from the perspective of White.
+```py
+# Set perspective to be from the perspective of the side to move
+stockfish.is_turn_perspective(True)
+
+# Set perspective to be from the perspective of White
+stockfish.is_turn_perspective(False)
+```
+
 
 ### Get Stockfish's win/draw/loss stats for the side to move in the current position  
 Before calling this function, it is recommended that you first check if your version of Stockfish is recent enough to display WDL stats. To do this,  

--- a/README.md
+++ b/README.md
@@ -129,17 +129,33 @@ True
 ```
 
 ### Get info on the top n moves
+Get moves, centipawns, and mates for the top n moves. If the move is a mate, the Centipawn value will be None, and vice versa.
+
 ```python
-stockfish.get_top_moves(3, include_info=False)
+stockfish.get_top_moves(3)
+# [
+#   {'Move': 'f5h7', 'Centipawn': None, 'Mate': 1},
+#   {'Move': 'f5d7', 'Centipawn': 713, 'Mate': None},
+#   {'Move': 'f5h5', 'Centipawn': -31, 'Mate': None}
+# ]
 ```
-Optional parameter `include_info` specifies whether to include the full info from the engine in the returned dictionary, including seldepth, multipv, time, nodes, nps, and wdl if available. Boolean. Default is `False`.
-```text
-[
-    {'Move': 'f5h7', 'Centipawn': None, 'Mate': 1},
-    {'Move': 'f5d7', 'Centipawn': 713, 'Mate': None},
-    {'Move': 'f5h5', 'Centipawn': -31, 'Mate': None}
-]
+Optional parameter `verbose` (default `False`) specifies whether to include the full info from the engine in the returned dictionary, including SelectiveDepth, Nodes, NodesPerSecond, Time, MultiPVLine, and WDL if available.
+```py
+stockfish.get_top_moves(1, verbose=True)
+# [{
+#   "Move":"d6e7",
+#   "Centipawn":-408,
+#   "Mate":"None",
+#   "Nodes":"2767506",
+#   "NodesPerSecond":"526442",
+#   "Time":"5257",
+#   "SelectiveDepth":"31",
+#   "MultiPVLine":"1",
+#   "WDL":"0 0 1000"
+# }]
 ```
+Optional parameter `num_nodes` specifies the number of nodes to search. If num_nodes is 0, then the engine will search until it configured depth is reached.
+
 
 ### Get Stockfish's win/draw/loss stats for the side to move in the current position  
 Before calling this function, it is recommended that you first check if your version of Stockfish is recent enough to display WDL stats. To do this,  

--- a/README.md
+++ b/README.md
@@ -166,10 +166,14 @@ Optional parameter `num_nodes` specifies the number of nodes to search. If num_n
 You can set the perspective of the evaluation to be from the perspective of the side to move, or from the perspective of White.
 ```py
 # Set the perspective of the evaluation to be from the point of view of the side to move
-stockfish.is_turn_perspective(True)
+stockfish.set_turn_perspective(True)
 
 # Set the perspective of the evaluation to be from White's perspective
-stockfish.is_turn_perspective(False)
+stockfish.set_turn_perspective(False)
+
+# Get the current perspective of the evaluation
+is_turn_perspective = stockfish.get_turn_perspective()
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ True
 
 ### Get info on the top n moves
 ```python
-stockfish.get_top_moves(3)
+stockfish.get_top_moves(3, include_info=False)
 ```
+Optional parameter `include_info` specifies whether to include the full info from the engine in the returned dictionary, including seldepth, multipv, time, nodes, nps, and wdl if available. Boolean. Default is `False`.
 ```text
 [
     {'Move': 'f5h7', 'Centipawn': None, 'Mate': 1},

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -135,7 +135,7 @@ class Stockfish:
             new_param_values["Hash"] = hash_value
 
         for name, value in new_param_values.items():
-            self._set_option(name, value, True)
+            self._set_option(name, value)
         self.set_fen_position(self.get_fen_position(), False)
         # Getting SF to set the position again, since UCI option(s) have been updated.
 
@@ -619,7 +619,7 @@ class Stockfish:
 
         # set MultiPV to num_top_moves requested
         if num_top_moves != self._parameters["MultiPV"]:
-            self._set_option("MultiPV", num_top_moves, True)
+            self._set_option("MultiPV", num_top_moves)
 
         # start engine
         # will go until reaches self._depth or self._num_nodes
@@ -740,7 +740,7 @@ class Stockfish:
 
         # reset MultiPV to global value
         if old_multipv != self._parameters["MultiPV"]:
-            self._set_option("MultiPV", old_multipv, True)
+            self._set_option("MultiPV", old_multipv)
 
         # reset self._num_nodes to global value
         if old_num_nodes != self._num_nodes:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -334,14 +334,14 @@ class Stockfish:
             {"UCI_LimitStrength": "true", "UCI_Elo": elo_rating}
         )
 
-    def set_depth(self, depth: int = 2) -> None:
+    def set_depth(self, depth: int = 15) -> None:
         """Sets current depth of Stockfish engine.
 
         Args:
-            depth_value: Depth option higher than 1
+            depth: Depth as integer higher than 1
         """
-        if not isinstance(depth, int):
-            raise TypeError("depth must be an integer")
+        if not isinstance(depth, int) or depth < 1 or isinstance(depth, bool):
+            raise TypeError("depth must be an integer higher than 1")
         self._depth = depth
 
     def get_depth(self) -> int:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -565,7 +565,6 @@ class Stockfish:
         num_top_moves: int = 5,
         verbose: bool = False,
         num_nodes: int = 0,
-        depth: int = 15,
     ) -> List[dict]:
         """Returns info on the top moves in the position.
 
@@ -584,10 +583,6 @@ class Stockfish:
               Option to search until a certain number of nodes have been searched, instead of depth.
               Default is 0.
 
-            depth:
-              Option to search until a certain depth has been reached, instead of nodes.
-              Default is 15.
-
         Returns:
             A list of dictionaries, where each dictionary contains keys for Move, Centipawn, and Mate.
             The corresponding value for either the Centipawn or Mate key will be None.
@@ -599,9 +594,6 @@ class Stockfish:
 
         if num_top_moves <= 0:
             raise ValueError("num_top_moves is not a positive number.")
-
-        if depth != 15 and num_nodes > 0:
-            raise ValueError("depth and num_nodes should not be set at the same time.")
 
         # to get number of top moves, we use Stockish's MultiPV option (ie. multiple principal variations)
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -343,7 +343,7 @@ class Stockfish:
             depth: Depth as integer higher than 1
         """
         if not isinstance(depth, int) or depth < 1 or isinstance(depth, bool):
-            raise TypeError("depth must be an integer higher than 1")
+            raise TypeError("depth must be an integer higher than 0")
         self._depth = depth
 
     def get_depth(self) -> int:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -65,9 +65,9 @@ class Stockfish:
 
         self._put("uci")
 
-        self._depth = depth
-        self._num_nodes = num_nodes
-        self._is_turn_perspective = is_turn_perspective
+        self._depth: int = depth
+        self._num_nodes: int = num_nodes
+        self._is_turn_perspective: bool = is_turn_perspective
         self.info: str = ""
 
         self._parameters: dict = {}

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -30,7 +30,7 @@ class Stockfish:
         depth: int = 15,
         parameters: Optional[dict] = None,
         num_nodes: int = 1000000,
-        is_turn_perspective: bool = True,
+        turn_perspective: bool = True,
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -68,7 +68,7 @@ class Stockfish:
 
         self.set_depth(depth)
         self.set_num_nodes(num_nodes)
-        self.set_is_turn_perspective(is_turn_perspective)
+        self.set_turn_perspective(turn_perspective)
 
         self.info: str = ""
 
@@ -368,21 +368,21 @@ class Stockfish:
         """Returns configured number of nodes to search"""
         return self._num_nodes
 
-    def set_is_turn_perspective(self, is_turn_perspective: bool = True) -> None:
+    def set_turn_perspective(self, turn_perspective: bool = True) -> None:
         """Sets perspective of centipawn and WDL evaluations.
 
         Args:
-            is_turn_perspective:
+            turn_perspective:
               Boolean whether perspective is turn-based. Default True.
               If False, returned evaluations are from White's perspective.
         """
-        if not isinstance(is_turn_perspective, bool):
-            raise TypeError("is_turn_perspective must be a Boolean")
-        self._is_turn_perspective = is_turn_perspective
+        if not isinstance(turn_perspective, bool):
+            raise TypeError("turn_perspective must be a Boolean")
+        self._turn_perspective = turn_perspective
 
-    def get_is_turn_perspective(self) -> bool:
+    def get_turn_perspective(self) -> bool:
         """Returns whether centipawn and WDL values are set from turn perspective."""
-        return self._is_turn_perspective
+        return self._turn_perspective
 
     def get_best_move(
         self, wtime: Optional[int] = None, btime: Optional[int] = None
@@ -649,12 +649,10 @@ class Stockfish:
 
         top_moves: List[dict] = []
 
-        # set perspective of evaluations. if get_is_turn_perspective() is True, or white to move,
+        # set perspective of evaluations. if get_turn_perspective() is True, or white to move,
         # use Stockfish' values, otherwise invert values.
         perspective = (
-            1
-            if self.get_is_turn_perspective() or ("w" in self.get_fen_position())
-            else -1
+            1 if self.get_turn_perspective() or ("w" in self.get_fen_position()) else -1
         )
 
         # loop through Stockfish output lines in reverse order

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -610,7 +610,6 @@ class Stockfish:
 
         if num_top_moves <= 0:
             raise ValueError("num_top_moves is not a positive number.")
-
         # to get number of top moves, we use Stockfish's MultiPV option (ie. multiple principal variations)
 
         # remember global values
@@ -642,7 +641,6 @@ class Stockfish:
 
         # Stockfish is now done evaluating the position,
         # and the output is stored in the list 'lines'
-
         top_moves: List[dict] = []
 
         # set perspective of evaluations. if get_turn_perspective() is True, or white to move,
@@ -672,23 +670,6 @@ class Stockfish:
             # if we're searching nodes and the line has less than desired number of nodes, we're done
             if (num_nodes > 0) and (int(self._pick(line, "nodes")) < self._num_nodes):
                 break
-
-            # gather info on "num_top_moves" multipv lines
-            # multiPV_number = int(current_line[current_line.index("multipv") + 1])
-
-            # should never happen
-            # if multiPV_number > num_top_moves:
-            #     continue
-
-            # should always be the case
-            # if multiPV_number <= num_top_moves:
-
-            # has_centipawn_value = "cp" in current_line
-            # has_mate_value = "mate" in current_line
-
-            # unnecessary check? should never happen, unless major malfunction
-            # if has_centipawn_value == has_mate_value:
-            # raise RuntimeError("Having a centipawn value and mate value should be mutually exclusive.")
 
             move_evaluation = {
                 # get move

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -611,7 +611,7 @@ class Stockfish:
         if num_top_moves <= 0:
             raise ValueError("num_top_moves is not a positive number.")
 
-        # to get number of top moves, we use Stockish's MultiPV option (ie. multiple principal variations)
+        # to get number of top moves, we use Stockfish's MultiPV option (ie. multiple principal variations)
 
         # remember global values
         old_multipv = self._parameters["MultiPV"]
@@ -649,10 +649,12 @@ class Stockfish:
 
         top_moves: List[dict] = []
 
-        # set perspective of evaluations. if is_turn_perspective is True, or white to move, use Stockfish' values.
-        # otherwise invert values.
+        # set perspective of evaluations. if get_is_turn_perspective() is True, or white to move,
+        # use Stockfish' values, otherwise invert values.
         perspective = (
-            1 if self._is_turn_perspective or ("w" in self.get_fen_position()) else -1
+            1
+            if self.get_is_turn_perspective() or ("w" in self.get_fen_position())
+            else -1
         )
 
         # loop through Stockfish output lines in reverse order

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -25,12 +25,12 @@ class Stockfish:
     # Used in test_models: will count how many times the del function is called.
 
     def __init__(
-        self, 
-        path: str = "stockfish", 
-        depth: int = 15, 
+        self,
+        path: str = "stockfish",
+        depth: int = 15,
         parameters: Optional[dict] = None,
-        num_nodes: int = 1000000, 
-        turn_perspective: bool = True
+        num_nodes: int = 1000000,
+        turn_perspective: bool = True,
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -182,7 +182,7 @@ class Stockfish:
 
     def _go(self) -> None:
         self._put(f"go depth {self.depth}")
-    
+
     def _go_nodes(self) -> None:
         self._put(f"go nodes {self._num_nodes}")
 
@@ -333,7 +333,7 @@ class Stockfish:
         self.update_engine_parameters(
             {"UCI_LimitStrength": "true", "UCI_Elo": elo_rating}
         )
-    
+
     def set_depth(self, depth_value: int = 2) -> None:
         """Sets current depth of stockfish engine.
 
@@ -358,9 +358,9 @@ class Stockfish:
         """Sets perspective of centipawn and WDL evaluations.
 
         Args:
-            turn_perspective: 
+            turn_perspective:
               Boolean whether perspective is turn-based. Default True.
-              If False, returned evaluations are from White's perspective. 
+              If False, returned evaluations are from White's perspective.
         """
         self._turn_perspective = turn_perspective
 
@@ -560,11 +560,10 @@ class Stockfish:
             elif splitted_text[0] == "bestmove":
                 return evaluation
 
-   
     def get_top_moves(
-        self, 
-        num_top_moves: int = 5, 
-        verbose: bool = False, 
+        self,
+        num_top_moves: int = 5,
+        verbose: bool = False,
         num_nodes: int = 0,
         depth: int = 15,
     ) -> List[dict]:
@@ -580,13 +579,13 @@ class Stockfish:
               Option to include the full info from the engine in the returned dictionary,
               including seldepth, multipv, time, nodes, nps, and wdl if available.
               Boolean. Default is False.
-            
+
             num_nodes:
-              Option to search until a certain number of nodes have been searched, instead of depth. 
+              Option to search until a certain number of nodes have been searched, instead of depth.
               Default is 0.
 
             depth:
-              Option to search until a certain depth has been reached, instead of nodes. 
+              Option to search until a certain depth has been reached, instead of nodes.
               Default is 15.
 
         Returns:
@@ -600,11 +599,11 @@ class Stockfish:
 
         if num_top_moves <= 0:
             raise ValueError("num_top_moves is not a positive number.")
-        
+
         if depth != 15 and num_nodes > 0:
             raise ValueError("depth and num_nodes should not be set at the same time.")
 
-        # to get number of top moves, we use Stockish's MultiPV option (ie. multiple principal variations) 
+        # to get number of top moves, we use Stockish's MultiPV option (ie. multiple principal variations)
 
         # remember global values
         old_multipv = self._parameters["MultiPV"]
@@ -626,7 +625,7 @@ class Stockfish:
         # self._go() if nodes else self._go_nodes()
 
         lines = []
-        
+
         # parse output into a list of lists
         # this loop will run until Stockfish has finished evaluating the position
         while True:
@@ -636,19 +635,20 @@ class Stockfish:
             # The "bestmove" line is the last line of the evaluation.
             if split_text[0] == "bestmove":
                 break
-        
+
         # Stockfish is now done evaluating the position,
         # and the output is stored in the list 'lines'
 
         top_moves: List[dict] = []
-        
+
         # set perspective of evaluations. if turn_perspective is True, or white to move, use Stockfish' values.
         # otherwise invert values.
-        perspective = 1 if self._turn_perspective or ("w" in self.get_fen_position()) else -1
+        perspective = (
+            1 if self._turn_perspective or ("w" in self.get_fen_position()) else -1
+        )
 
         # loop through Stockfish output lines in reverse order
         for current_line in reversed(lines):
-
             # if the line is a "bestmove" line, and the best move is "(none)", then
             # there are no top moves, and we're done. otherwise, continue with next line
             if current_line[0] == "bestmove":
@@ -662,13 +662,17 @@ class Stockfish:
                 break
 
             # if we're searching depth and the line is not our desired depth, we're done
-            if (num_nodes == 0) and (current_line[current_line.index("depth") + 1] != self.depth):
+            if (num_nodes == 0) and (
+                current_line[current_line.index("depth") + 1] != self.depth
+            ):
                 break
 
             # if we're searching nodes and the line has less than desired number of nodes, we're done
-            if (num_nodes > 0) and (int(current_line[current_line.index("nodes") + 1]) < self._num_nodes):
+            if (num_nodes > 0) and (
+                int(current_line[current_line.index("nodes") + 1]) < self._num_nodes
+            ):
                 break
-        
+
             # gather info on "num_top_moves" multipv lines
             # multiPV_number = int(current_line[current_line.index("multipv") + 1])
 
@@ -684,22 +688,18 @@ class Stockfish:
 
             # unnecessary check? should never happen, unless major malfunction
             # if has_centipawn_value == has_mate_value:
-                # raise RuntimeError("Having a centipawn value and mate value should be mutually exclusive.")
-            
-            move_evaluation = {
+            # raise RuntimeError("Having a centipawn value and mate value should be mutually exclusive.")
 
+            move_evaluation = {
                 # get move
                 "Move": current_line[current_line.index("pv") + 1],
-
                 # get cp if available
                 "Centipawn": int(current_line[current_line.index("cp") + 1])
                 * perspective
                 if "cp" in current_line
                 else None,
-
                 # get mate if available
-                "Mate": int(current_line[current_line.index("mate") + 1])
-                * perspective
+                "Mate": int(current_line[current_line.index("mate") + 1]) * perspective
                 if "mate" in current_line
                 else None,
             }
@@ -707,20 +707,27 @@ class Stockfish:
             # add more info if verbose
             if verbose:
                 move_evaluation["Nodes"] = current_line[current_line.index("nodes") + 1]
-                move_evaluation["NodesPerSecond"] = current_line[current_line.index("nps") + 1]
+                move_evaluation["NodesPerSecond"] = current_line[
+                    current_line.index("nps") + 1
+                ]
                 move_evaluation["Time"] = current_line[current_line.index("time") + 1]
-                move_evaluation["SelectiveDepth"] = current_line[current_line.index("seldepth") + 1]
-                move_evaluation["MultiPVLine"] = current_line[current_line.index("multipv") + 1]
+                move_evaluation["SelectiveDepth"] = current_line[
+                    current_line.index("seldepth") + 1
+                ]
+                move_evaluation["MultiPVLine"] = current_line[
+                    current_line.index("multipv") + 1
+                ]
 
                 # add wdl if available
                 if self.does_current_engine_version_have_wdl_option():
-                    move_evaluation["WDL"] = " ".join([  
+                    move_evaluation["WDL"] = " ".join(
+                        [
                             current_line[current_line.index("wdl") + 1],
                             current_line[current_line.index("wdl") + 2],
                             current_line[current_line.index("wdl") + 3],
                         ][::perspective]
                     )
-                
+
             # add move to list of top moves
             top_moves.insert(0, move_evaluation)
 
@@ -728,13 +735,13 @@ class Stockfish:
         if old_multipv != self._parameters["MultiPV"]:
             self._set_option("MultiPV", old_multipv)
             self._parameters.update({"MultiPV": old_multipv})
-        
+
         # reset self._num_nodes to global value
         if old_num_nodes != self._num_nodes:
             self._num_nodes = old_num_nodes
 
         return top_moves
-    
+
     @dataclass
     class BenchmarkParameters:
         ttSize: int = 16
@@ -780,8 +787,6 @@ class Stockfish:
             splitted_text = text.split(" ")
             if splitted_text[0] == "Nodes/second":
                 return text
-
-    
 
     class Piece(Enum):
         WHITE_PAWN = "P"

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -48,6 +48,7 @@ class Stockfish:
             "UCI_LimitStrength": "false",
             "UCI_Elo": 1350,
         }
+
         self._path = path
         self._stockfish = subprocess.Popen(
             self._path,
@@ -65,9 +66,10 @@ class Stockfish:
 
         self._put("uci")
 
-        self._depth: int = depth
-        self._num_nodes: int = num_nodes
-        self._is_turn_perspective: bool = is_turn_perspective
+        self.set_depth(depth)
+        self.set_num_nodes(num_nodes)
+        self.set_is_turn_perspective(is_turn_perspective)
+
         self.info: str = ""
 
         self._parameters: dict = {}

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -374,6 +374,8 @@ class Stockfish:
               Boolean whether perspective is turn-based. Default True.
               If False, returned evaluations are from White's perspective.
         """
+        if not isinstance(is_turn_perspective, bool):
+            raise TypeError("is_turn_perspective must be a Boolean")
         self._is_turn_perspective = is_turn_perspective
 
     def get_is_turn_perspective(self) -> bool:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -30,7 +30,7 @@ class Stockfish:
         depth: int = 15,
         parameters: Optional[dict] = None,
         num_nodes: int = 1000000,
-        turn_perspective: bool = True,
+        is_turn_perspective: bool = True,
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -67,7 +67,7 @@ class Stockfish:
 
         self.depth = str(depth)
         self._num_nodes = num_nodes
-        self._turn_perspective = turn_perspective
+        self._is_turn_perspective = is_turn_perspective
         self.info: str = ""
 
         self._parameters: dict = {}
@@ -335,7 +335,7 @@ class Stockfish:
         )
 
     def set_depth(self, depth_value: int = 2) -> None:
-        """Sets current depth of stockfish engine.
+        """Sets current depth of Stockfish engine.
 
         Args:
             depth_value: Depth option higher than 1
@@ -346,7 +346,7 @@ class Stockfish:
         """Sets current number of nodes of Stockfish engine.
 
         Args:
-            num_nodes: Number of nodes option higher than 1000000
+            num_nodes: Number of nodes for Stockfish to search
         """
         self._num_nodes = num_nodes
 
@@ -354,19 +354,19 @@ class Stockfish:
         """Returns configured number of nodes to search"""
         return self._num_nodes
 
-    def set_turn_perspective(self, turn_perspective: bool = True) -> None:
+    def set_is_turn_perspective(self, is_turn_perspective: bool = True) -> None:
         """Sets perspective of centipawn and WDL evaluations.
 
         Args:
-            turn_perspective:
+            is_turn_perspective:
               Boolean whether perspective is turn-based. Default True.
               If False, returned evaluations are from White's perspective.
         """
-        self._turn_perspective = turn_perspective
+        self._is_turn_perspective = is_turn_perspective
 
-    def get_turn_perspective(self) -> bool:
+    def get_is_turn_perspective(self) -> bool:
         """Returns whether centipawn and WDL values are set from turn perspective."""
-        return self._turn_perspective
+        return self._is_turn_perspective
 
     def get_best_move(
         self, wtime: Optional[int] = None, btime: Optional[int] = None
@@ -641,10 +641,10 @@ class Stockfish:
 
         top_moves: List[dict] = []
 
-        # set perspective of evaluations. if turn_perspective is True, or white to move, use Stockfish' values.
+        # set perspective of evaluations. if is_turn_perspective is True, or white to move, use Stockfish' values.
         # otherwise invert values.
         perspective = (
-            1 if self._turn_perspective or ("w" in self.get_fen_position()) else -1
+            1 if self._is_turn_perspective or ("w" in self.get_fen_position()) else -1
         )
 
         # loop through Stockfish output lines in reverse order

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -339,8 +339,8 @@ class Stockfish:
     def set_depth(self, depth: int = 15) -> None:
         """Sets current depth of Stockfish engine.
 
-        Args:
-depth: Depth as integer 1 or higher
+                Args:
+        depth: Depth as integer 1 or higher
         """
         if not isinstance(depth, int) or depth < 1 or isinstance(depth, bool):
             raise TypeError("depth must be an integer higher than 0")

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -734,7 +734,7 @@ class Stockfish:
 
         return top_moves
 
-    def _pick(self, line: list = [], value: str = "", index: int = 1) -> str:
+    def _pick(self, line: list, value: str = "", index: int = 1) -> str:
         return line[line.index(value) + index]
 
     @dataclass

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -339,8 +339,8 @@ class Stockfish:
     def set_depth(self, depth: int = 15) -> None:
         """Sets current depth of Stockfish engine.
 
-                Args:
-        depth: Depth as integer 1 or higher
+        Args:
+            depth: Depth as integer 1 or higher
         """
         if not isinstance(depth, int) or depth < 1 or isinstance(depth, bool):
             raise TypeError("depth must be an integer higher than 0")

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -646,7 +646,7 @@ class Stockfish:
         top_moves: List[dict] = []
 
         # set perspective of evaluations. if get_turn_perspective() is True, or white to move,
-        # use Stockfish' values, otherwise invert values.
+        # use Stockfish's values, otherwise invert values.
         perspective = (
             1 if self.get_turn_perspective() or ("w" in self.get_fen_position()) else -1
         )

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -619,8 +619,7 @@ class Stockfish:
 
         # set MultiPV to num_top_moves requested
         if num_top_moves != self._parameters["MultiPV"]:
-            self._set_option("MultiPV", num_top_moves)
-            self._parameters.update({"MultiPV": num_top_moves})
+            self._set_option("MultiPV", num_top_moves, True)
 
         # start engine
         # will go until reaches self._depth or self._num_nodes
@@ -741,8 +740,7 @@ class Stockfish:
 
         # reset MultiPV to global value
         if old_multipv != self._parameters["MultiPV"]:
-            self._set_option("MultiPV", old_multipv)
-            self._parameters.update({"MultiPV": old_multipv})
+            self._set_option("MultiPV", old_multipv, True)
 
         # reset self._num_nodes to global value
         if old_num_nodes != self._num_nodes:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -28,8 +28,8 @@ class Stockfish:
         self, 
         path: str = "stockfish", 
         depth: int = 15, 
-        num_nodes: int = 1000000, 
         parameters: dict = None,
+        num_nodes: int = 1000000, 
         turn_perspective: bool = True
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
@@ -365,7 +365,7 @@ class Stockfish:
         self._turn_perspective = turn_perspective
 
     def get_turn_perspective(self) -> bool:
-        """Returns whether centipawn and WDL values are set."""
+        """Returns whether centipawn and WDL values are set from turn perspective."""
         return self._turn_perspective
 
     def get_best_move(self, wtime: int = None, btime: int = None) -> Optional[str]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -361,7 +361,7 @@ class Stockfish:
             or isinstance(num_nodes, bool)
             or num_nodes < 1
         ):
-            raise TypeError("num_nodes must be an integer higher than 1")
+            raise TypeError("num_nodes must be an integer higher than 0")
         self._num_nodes = num_nodes
 
     def get_num_nodes(self) -> int:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -354,6 +354,12 @@ class Stockfish:
         Args:
             num_nodes: Number of nodes for Stockfish to search
         """
+        if (
+            not isinstance(num_nodes, int)
+            or isinstance(num_nodes, bool)
+            or num_nodes < 1
+        ):
+            raise TypeError("num_nodes must be an integer higher than 1")
         self._num_nodes = num_nodes
 
     def get_num_nodes(self) -> int:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -340,7 +340,7 @@ class Stockfish:
         """Sets current depth of Stockfish engine.
 
         Args:
-            depth: Depth as integer higher than 1
+depth: Depth as integer 1 or higher
         """
         if not isinstance(depth, int) or depth < 1 or isinstance(depth, bool):
             raise TypeError("depth must be an integer higher than 0")

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -65,7 +65,7 @@ class Stockfish:
 
         self._put("uci")
 
-        self.depth = str(depth)
+        self._depth = depth
         self._num_nodes = num_nodes
         self._is_turn_perspective = is_turn_perspective
         self.info: str = ""
@@ -181,7 +181,7 @@ class Stockfish:
             pass
 
     def _go(self) -> None:
-        self._put(f"go depth {self.depth}")
+        self._put(f"go depth {self._depth}")
 
     def _go_nodes(self) -> None:
         self._put(f"go nodes {self._num_nodes}")
@@ -334,13 +334,19 @@ class Stockfish:
             {"UCI_LimitStrength": "true", "UCI_Elo": elo_rating}
         )
 
-    def set_depth(self, depth_value: int = 2) -> None:
+    def set_depth(self, depth: int = 2) -> None:
         """Sets current depth of Stockfish engine.
 
         Args:
             depth_value: Depth option higher than 1
         """
-        self.depth = str(depth_value)
+        if not isinstance(depth, int):
+            raise TypeError("depth must be an integer")
+        self._depth = depth
+
+    def get_depth(self) -> int:
+        """Returns configured depth to search"""
+        return self._depth
 
     def set_num_nodes(self, num_nodes: int = 1000000) -> None:
         """Sets current number of nodes of Stockfish engine.
@@ -655,7 +661,7 @@ class Stockfish:
 
             # if we're searching depth and the line is not our desired depth, we're done
             if (num_nodes == 0) and (
-                current_line[current_line.index("depth") + 1] != self.depth
+                int(current_line[current_line.index("depth") + 1]) != self._depth
             ):
                 break
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -514,7 +514,9 @@ class Stockfish:
             elif splitted_text[0] == "bestmove":
                 return evaluation
 
-    def get_top_moves(self, num_top_moves: int = 5) -> List[dict]:
+    def get_top_moves(
+        self, num_top_moves: int = 5, include_info: bool = False
+    ) -> List[dict]:
         """Returns info on the top moves in the position.
 
         Args:
@@ -522,10 +524,18 @@ class Stockfish:
                 The number of moves to return info on, assuming there are at least
                 those many legal moves.
 
+            include_info:
+                Option to include the full info from the engine in the returned dictionary,
+                including seldepth, multipv, time, nodes, nps, and wdl if available.
+                Boolean. Default is False.
+
         Returns:
             A list of dictionaries. In each dictionary, there are keys for Move, Centipawn, and Mate;
             the corresponding value for either the Centipawn or Mate key will be None.
             If there are no moves in the position, an empty list is returned.
+
+            If include_info is True, the dictionary will also include the keys SelectiveDepth, Time,
+            Nodes, N/s, MultiPVLine, and WDL (if available). WDL is set from the White player's perspective.
         """
 
         if num_top_moves <= 0:
@@ -562,20 +572,44 @@ class Stockfish:
                         raise RuntimeError(
                             "Having a centipawn value and mate value should be mutually exclusive."
                         )
-                    top_moves.insert(
-                        0,
-                        {
-                            "Move": current_line[current_line.index("pv") + 1],
-                            "Centipawn": int(current_line[current_line.index("cp") + 1])
-                            * multiplier
-                            if has_centipawn_value
-                            else None,
-                            "Mate": int(current_line[current_line.index("mate") + 1])
-                            * multiplier
-                            if has_mate_value
-                            else None,
-                        },
-                    )
+                    move_evaluation = {
+                        "Move": current_line[current_line.index("pv") + 1],
+                        "Centipawn": int(current_line[current_line.index("cp") + 1])
+                        * multiplier
+                        if has_centipawn_value
+                        else None,
+                        "Mate": int(current_line[current_line.index("mate") + 1])
+                        * multiplier
+                        if has_mate_value
+                        else None,
+                    }
+                    if include_info == True:
+                        move_evaluation.update(
+                            {
+                                "Nodes": current_line[current_line.index("nodes") + 1],
+                                "N/s": current_line[current_line.index("nps") + 1],
+                                "Time": current_line[current_line.index("time") + 1],
+                                "SelectiveDepth": current_line[
+                                    current_line.index("seldepth") + 1
+                                ],
+                                "MultiPVLine": current_line[
+                                    current_line.index("multipv") + 1
+                                ],
+                            }
+                        )
+                        if self.does_current_engine_version_have_wdl_option():
+                            move_evaluation.update(
+                                {
+                                    "WDL": " ".join(
+                                        [
+                                            current_line[current_line.index("wdl") + 1],
+                                            current_line[current_line.index("wdl") + 2],
+                                            current_line[current_line.index("wdl") + 3],
+                                        ][::multiplier]
+                                    )
+                                }
+                            )
+                    top_moves.insert(0, move_evaluation)
             else:
                 break
         if old_MultiPV_value != self._parameters["MultiPV"]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -583,7 +583,7 @@ class Stockfish:
                         if has_mate_value
                         else None,
                     }
-                    if include_info == True:
+                    if include_info:
                         move_evaluation.update(
                             {
                                 "Nodes": current_line[current_line.index("nodes") + 1],

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -30,8 +30,9 @@ class TestStockfish:
         assert sf._num_nodes == 1000
         assert sf._is_turn_perspective is False
         assert sf._parameters["Threads"] == 2
+        assert sf._parameters["UCI_Elo"] == 1500
 
-    def test_instantiation_raising_type_errors(self):
+    def test_instantiation_raises_type_errors(self):
         with pytest.raises(TypeError):
             Stockfish(depth="20")
         with pytest.raises(TypeError):
@@ -485,7 +486,7 @@ class TestStockfish:
         stockfish.get_best_move()
         assert "depth 15" in stockfish.info
 
-    def test_set_depth_type_error(self, stockfish):
+    def test_set_depth_raises_type_error(self, stockfish):
         with pytest.raises(TypeError):
             stockfish.set_depth("12")
         with pytest.raises(TypeError):
@@ -511,7 +512,7 @@ class TestStockfish:
         stockfish.set_num_nodes()
         assert stockfish._num_nodes == 1000000
 
-    def test_set_num_nodes_type_error(self, stockfish):
+    def test_set_num_nodes_raises_type_error(self, stockfish):
         with pytest.raises(TypeError):
             stockfish.set_num_nodes("100")
         with pytest.raises(TypeError):
@@ -684,7 +685,7 @@ class TestStockfish:
         assert stockfish.get_num_nodes() == 2000000
         assert stockfish.get_parameters()["MultiPV"] == 4
 
-    def test_get_top_moves_raising_error_num_top_moves(self, stockfish):
+    def test_get_top_moves_raises_value_error(self, stockfish):
         stockfish.set_fen_position(
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
         )
@@ -703,7 +704,7 @@ class TestStockfish:
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] < 0
 
-    def test_is_turn_perspective_type_error(self, stockfish):
+    def test_is_turn_perspective_raises_type_error(self, stockfish):
         with pytest.raises(TypeError):
             stockfish.set_is_turn_perspective("not a bool")
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -630,12 +630,12 @@ class TestStockfish:
         with pytest.raises(ValueError):
             stockfish.get_top_moves(2, num_nodes=1000, depth=10)
 
-    def test_turn_perspective(self, stockfish):
+    def test_is_turn_perspective(self, stockfish):
         stockfish.set_depth(15)
         stockfish.set_fen_position("8/2q2pk1/4b3/1p6/7P/Q1p3P1/2B2P2/6K1 b - - 3 50")
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] > 0
-        stockfish.set_turn_perspective(False)
+        stockfish.set_is_turn_perspective(False)
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] < 0
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -39,6 +39,7 @@ class TestStockfish:
     def test_constructor_raises_type_errors(self, parameters):
         with pytest.raises(TypeError):
             Stockfish(**parameters)
+
     def test_get_best_move_first_move(self, stockfish):
         best_move = stockfish.get_best_move()
         assert best_move in (

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -24,7 +24,7 @@ class TestStockfish:
             depth=20,
             num_nodes=1000,
             is_turn_perspective=False,
-            parameters={"Threads": 2},
+            parameters={"Threads": 2, "UCI_Elo": 1500},
         )
         assert sf._depth == 20
         assert sf._num_nodes == 1000
@@ -699,6 +699,7 @@ class TestStockfish:
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] > 0
         stockfish.set_is_turn_perspective(False)
+        assert stockfish.get_is_turn_perspective() is False
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] < 0
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -10,6 +10,35 @@ class TestStockfish:
     def stockfish(self):
         return Stockfish()
 
+    def test_instantiation_defaults(self):
+        sf = Stockfish()
+        assert sf is not None
+        assert sf._path == "stockfish"
+        assert sf._parameters == sf._DEFAULT_STOCKFISH_PARAMS
+        assert sf._depth == 15
+        assert sf._num_nodes == 1000000
+        assert sf._is_turn_perspective is True
+
+    def test_instantiation_options(self):
+        sf = Stockfish(
+            depth=20,
+            num_nodes=1000,
+            is_turn_perspective=False,
+            parameters={"Threads": 2},
+        )
+        assert sf._depth == 20
+        assert sf._num_nodes == 1000
+        assert sf._is_turn_perspective is False
+        assert sf._parameters["Threads"] == 2
+
+    def test_instantiation_raising_type_errors(self):
+        with pytest.raises(TypeError):
+            Stockfish(depth="20")
+        with pytest.raises(TypeError):
+            Stockfish(num_nodes="100")
+        with pytest.raises(TypeError):
+            Stockfish(is_turn_perspective="False")
+
     def test_get_best_move_first_move(self, stockfish):
         best_move = stockfish.get_best_move()
         assert best_move in (

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -618,11 +618,6 @@ class TestStockfish:
         assert len(stockfish.get_top_moves(2)) == 2
         assert stockfish.get_parameters()["MultiPV"] == 1
 
-    def test_get_top_moves_raising_error_depth_and_num_nodes_set(self, stockfish):
-        stockfish.set_fen_position("8/2q2pk1/4b3/1p6/7P/Q1p3P1/2B2P2/6K1 b - - 3 50")
-        with pytest.raises(ValueError):
-            stockfish.get_top_moves(2, num_nodes=1000, depth=10)
-
     def test_is_turn_perspective(self, stockfish):
         stockfish.set_depth(15)
         stockfish.set_fen_position("8/2q2pk1/4b3/1p6/7P/Q1p3P1/2B2P2/6K1 b - - 3 50")

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -476,6 +476,28 @@ class TestStockfish:
         assert stockfish.get_depth() == 20
         assert stockfish._depth == 20
 
+    def test_set_num_nodes(self, stockfish):
+        stockfish.set_num_nodes(100)
+        assert stockfish._num_nodes == 100
+        stockfish.set_num_nodes()
+        assert stockfish._num_nodes == 1000000
+
+    def test_set_num_nodes_type_error(self, stockfish):
+        with pytest.raises(TypeError):
+            stockfish.set_num_nodes("100")
+        with pytest.raises(TypeError):
+            stockfish.set_num_nodes(100.1)
+        with pytest.raises(TypeError):
+            stockfish.set_num_nodes(None)
+        with pytest.raises(TypeError):
+            stockfish.set_num_nodes(True)
+
+    def test_get_num_nodes(self, stockfish):
+        stockfish.set_num_nodes(100)
+        assert stockfish.get_num_nodes() == 100
+        stockfish.set_num_nodes()
+        assert stockfish.get_num_nodes() == 1000000
+
     def test_get_best_move_wrong_position(self, stockfish):
         stockfish.set_depth(2)
         wrong_fen = "3kk3/8/8/8/8/8/8/3KK3 w - - 0 0"

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -673,6 +673,10 @@ class TestStockfish:
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] < 0
 
+    def test_is_turn_perspective_type_error(self, stockfish):
+        with pytest.raises(TypeError):
+            stockfish.set_is_turn_perspective("not a bool")
+
     def test_make_moves_from_current_position(self, stockfish):
         stockfish.set_fen_position(
             "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -485,7 +485,7 @@ class TestStockfish:
         stockfish.get_best_move()
         assert "depth 15" in stockfish.info
 
-@pytest.mark.parametrize("depth", ["12", True, 12.1, 0, None])
+    @pytest.mark.parametrize("depth", ["12", True, 12.1, 0, None])
     def test_set_depth_raises_type_error(self, stockfish, depth):
         with pytest.raises(TypeError):
             stockfish.set_depth(depth)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -448,9 +448,15 @@ class TestStockfish:
 
     def test_set_depth(self, stockfish):
         stockfish.set_depth(12)
-        assert stockfish.depth == "12"
+        assert stockfish._depth == 12
         stockfish.get_best_move()
         assert "depth 12" in stockfish.info
+
+    def test_get_depth(self, stockfish):
+        stockfish.set_depth(12)
+        assert stockfish.get_depth() == 12
+        stockfish.set_depth(20)
+        assert stockfish.get_depth() == 20
 
     def test_get_best_move_wrong_position(self, stockfish):
         stockfish.set_depth(2)
@@ -482,10 +488,10 @@ class TestStockfish:
         stockfish.get_best_move()
         assert "multipv 2" in stockfish_2.info
         assert "depth 16" in stockfish_2.info
-        assert stockfish_2.depth == "16"
+        assert stockfish_2._depth == 16
         assert "multipv 1" in stockfish.info
         assert "depth 15" in stockfish.info
-        assert stockfish.depth == "15"
+        assert stockfish._depth == 15
 
         stockfish_1_params = stockfish.get_parameters()
         stockfish_2_params = stockfish_2.get_parameters()
@@ -948,7 +954,7 @@ class TestStockfish:
     def test_is_fen_valid(self, stockfish):
         old_params = stockfish.get_parameters()
         old_info = stockfish.info
-        old_depth = stockfish.depth
+        old_depth = stockfish._depth
         old_fen = stockfish.get_fen_position()
         correct_fens = [
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
@@ -974,7 +980,7 @@ class TestStockfish:
         assert stockfish._stockfish.poll() is None
         assert stockfish.get_parameters() == old_params
         assert stockfish.info == old_info
-        assert stockfish.depth == old_depth
+        assert stockfish._depth == old_depth
         assert stockfish.get_fen_position() == old_fen
 
     def test_send_quit_command(self, stockfish):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -17,18 +17,18 @@ class TestStockfish:
         assert sf._parameters == sf._DEFAULT_STOCKFISH_PARAMS
         assert sf._depth == 15
         assert sf._num_nodes == 1000000
-        assert sf._is_turn_perspective is True
+        assert sf._turn_perspective is True
 
     def test_constructor_options(self):
         sf = Stockfish(
             depth=20,
             num_nodes=1000,
-            is_turn_perspective=False,
+            turn_perspective=False,
             parameters={"Threads": 2, "UCI_Elo": 1500},
         )
         assert sf._depth == 20
         assert sf._num_nodes == 1000
-        assert sf._is_turn_perspective is False
+        assert sf._turn_perspective is False
         assert sf._parameters["Threads"] == 2
         assert sf._parameters["UCI_Elo"] == 1500
 
@@ -38,7 +38,7 @@ class TestStockfish:
         with pytest.raises(TypeError):
             Stockfish(num_nodes="100")
         with pytest.raises(TypeError):
-            Stockfish(is_turn_perspective="False")
+            Stockfish(turn_perspective="False")
 
     def test_get_best_move_first_move(self, stockfish):
         best_move = stockfish.get_best_move()
@@ -693,19 +693,19 @@ class TestStockfish:
         assert len(stockfish.get_top_moves(2)) == 2
         assert stockfish.get_parameters()["MultiPV"] == 1
 
-    def test_is_turn_perspective(self, stockfish):
+    def test_turn_perspective(self, stockfish):
         stockfish.set_depth(15)
         stockfish.set_fen_position("8/2q2pk1/4b3/1p6/7P/Q1p3P1/2B2P2/6K1 b - - 3 50")
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] > 0
-        stockfish.set_is_turn_perspective(False)
-        assert stockfish.get_is_turn_perspective() is False
+        stockfish.set_turn_perspective(False)
+        assert stockfish.get_turn_perspective() is False
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] < 0
 
-    def test_is_turn_perspective_raises_type_error(self, stockfish):
+    def test_turn_perspective_raises_type_error(self, stockfish):
         with pytest.raises(TypeError):
-            stockfish.set_is_turn_perspective("not a bool")
+            stockfish.set_turn_perspective("not a bool")
 
     def test_make_moves_from_current_position(self, stockfish):
         stockfish.set_fen_position(

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1065,3 +1065,9 @@ class TestStockfish:
         stockfish.__del__()
         assert stockfish._stockfish.poll() is not None
         assert Stockfish._del_counter == old_del_counter + 1
+
+    def test_set_option(self, stockfish):
+        stockfish._set_option("MultiPV", 3)
+        assert stockfish.get_parameters()["MultiPV"] == 3
+        stockfish._set_option("MultiPV", 6, False)  # update_parameters_attribute
+        assert stockfish.get_parameters()["MultiPV"] == 3

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -32,14 +32,13 @@ class TestStockfish:
         assert sf._parameters["Threads"] == 2
         assert sf._parameters["UCI_Elo"] == 1500
 
-    def test_constructor_raises_type_errors(self):
+    @pytest.mark.parametrize(
+        "parameters",
+        [{"depth": "20"}, {"num_nodes": "100"}, {"turn_perspective": "False"}],
+    )
+    def test_constructor_raises_type_errors(self, parameters):
         with pytest.raises(TypeError):
-            Stockfish(depth="20")
-        with pytest.raises(TypeError):
-            Stockfish(num_nodes="100")
-        with pytest.raises(TypeError):
-            Stockfish(turn_perspective="False")
-
+            Stockfish(**parameters)
     def test_get_best_move_first_move(self, stockfish):
         best_move = stockfish.get_best_move()
         assert best_move in (

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -505,15 +505,10 @@ class TestStockfish:
         stockfish.set_num_nodes()
         assert stockfish._num_nodes == 1000000
 
+    @pytest.mark.parametrize("num_nodes", ["100", 100.1, None, True])
     def test_set_num_nodes_raises_type_error(self, stockfish):
         with pytest.raises(TypeError):
-            stockfish.set_num_nodes("100")
-        with pytest.raises(TypeError):
-            stockfish.set_num_nodes(100.1)
-        with pytest.raises(TypeError):
-            stockfish.set_num_nodes(None)
-        with pytest.raises(TypeError):
-            stockfish.set_num_nodes(True)
+            stockfish.set_num_nodes(num_nodes)
 
     def test_get_num_nodes(self, stockfish):
         stockfish.set_num_nodes(100)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -486,17 +486,10 @@ class TestStockfish:
         stockfish.get_best_move()
         assert "depth 15" in stockfish.info
 
-    def test_set_depth_raises_type_error(self, stockfish):
+@pytest.mark.parametrize("depth", ["12", True, 12.1, 0, None])
+    def test_set_depth_raises_type_error(self, stockfish, depth):
         with pytest.raises(TypeError):
-            stockfish.set_depth("12")
-        with pytest.raises(TypeError):
-            stockfish.set_depth(True)
-        with pytest.raises(TypeError):
-            stockfish.set_depth(12.1)
-        with pytest.raises(TypeError):
-            stockfish.set_depth(0)
-        with pytest.raises(TypeError):
-            stockfish.set_depth(None)
+            stockfish.set_depth(depth)
 
     def test_get_depth(self, stockfish):
         stockfish.set_depth(12)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -601,13 +601,6 @@ class TestStockfish:
         moves = stockfish.get_top_moves(2, num_nodes=1000000, verbose=True)
         assert int(moves[0]["Nodes"]) >= 1000000
 
-    def test_get_top_moves_depth(self, stockfish):
-        stockfish.set_fen_position("8/2q2pk1/4b3/1p6/7P/Q1p3P1/2B2P2/6K1 b - - 3 50")
-        moves = stockfish.get_top_moves(2, depth=10, verbose=True)
-        assert int(moves[0]["SelectiveDepth"]) >= 10
-        moves = stockfish.get_top_moves(2, depth=15, verbose=True)
-        assert int(moves[0]["SelectiveDepth"]) >= 15
-
     def test_get_top_moves_preserve_globals(self, stockfish):
         stockfish._set_option("MultiPV", 4)
         stockfish.set_num_nodes(2000000)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -451,12 +451,30 @@ class TestStockfish:
         assert stockfish._depth == 12
         stockfish.get_best_move()
         assert "depth 12" in stockfish.info
+        stockfish.set_depth()
+        assert stockfish._depth == 15
+        stockfish.get_best_move()
+        assert "depth 15" in stockfish.info
+
+    def test_set_depth_type_error(self, stockfish):
+        with pytest.raises(TypeError):
+            stockfish.set_depth("12")
+        with pytest.raises(TypeError):
+            stockfish.set_depth(True)
+        with pytest.raises(TypeError):
+            stockfish.set_depth(12.1)
+        with pytest.raises(TypeError):
+            stockfish.set_depth(0)
+        with pytest.raises(TypeError):
+            stockfish.set_depth(None)
 
     def test_get_depth(self, stockfish):
         stockfish.set_depth(12)
         assert stockfish.get_depth() == 12
+        assert stockfish._depth == 12
         stockfish.set_depth(20)
         assert stockfish.get_depth() == 20
+        assert stockfish._depth == 20
 
     def test_get_best_move_wrong_position(self, stockfish):
         stockfish.set_depth(2)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1071,3 +1071,10 @@ class TestStockfish:
         assert stockfish.get_parameters()["MultiPV"] == 3
         stockfish._set_option("MultiPV", 6, False)  # update_parameters_attribute
         assert stockfish.get_parameters()["MultiPV"] == 3
+
+    def test_pick(self, stockfish):
+        info = "info depth 10 seldepth 15 multipv 1 score cp -677 wdl 0 0 1000"
+        line = info.split(" ")
+        assert stockfish._pick(line, "depth") == "10"
+        assert stockfish._pick(line, "multipv") == "1"
+        assert stockfish._pick(line, "wdl", 3) == "1000"

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -506,7 +506,7 @@ class TestStockfish:
         assert stockfish._num_nodes == 1000000
 
     @pytest.mark.parametrize("num_nodes", ["100", 100.1, None, True])
-    def test_set_num_nodes_raises_type_error(self, stockfish):
+    def test_set_num_nodes_raises_type_error(self, stockfish, num_nodes):
         with pytest.raises(TypeError):
             stockfish.set_num_nodes(num_nodes)
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -10,7 +10,7 @@ class TestStockfish:
     def stockfish(self):
         return Stockfish()
 
-    def test_instantiation_defaults(self):
+    def test_constructor_defaults(self):
         sf = Stockfish()
         assert sf is not None
         assert sf._path == "stockfish"
@@ -19,7 +19,7 @@ class TestStockfish:
         assert sf._num_nodes == 1000000
         assert sf._is_turn_perspective is True
 
-    def test_instantiation_options(self):
+    def test_constructor_options(self):
         sf = Stockfish(
             depth=20,
             num_nodes=1000,
@@ -32,7 +32,7 @@ class TestStockfish:
         assert sf._parameters["Threads"] == 2
         assert sf._parameters["UCI_Elo"] == 1500
 
-    def test_instantiation_raises_type_errors(self):
+    def test_constructor_raises_type_errors(self):
         with pytest.raises(TypeError):
             Stockfish(depth="20")
         with pytest.raises(TypeError):
@@ -649,7 +649,6 @@ class TestStockfish:
 
     def test_get_top_moves_verbose(self, stockfish):
         stockfish.set_depth(15)
-        stockfish._set_option("MultiPV", 4)
         stockfish.set_fen_position("1rQ1r1k1/5ppp/8/8/1R6/8/2r2PPP/4R1K1 w - - 0 1")
         assert stockfish.get_top_moves(2, verbose=False) == [
             {"Move": "e1e8", "Centipawn": None, "Mate": 1},

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -571,6 +571,31 @@ class TestStockfish:
         assert stockfish.get_top_moves() == []
         assert stockfish.get_parameters()["MultiPV"] == 3
 
+    def test_get_top_moves_with_info(self, stockfish):
+        stockfish.set_depth(15)
+        stockfish._set_option("MultiPV", 4)
+        stockfish.set_fen_position("1rQ1r1k1/5ppp/8/8/1R6/8/2r2PPP/4R1K1 w - - 0 1")
+        assert stockfish.get_top_moves(2, include_info=False) == [
+            {"Move": "e1e8", "Centipawn": None, "Mate": 1},
+            {"Move": "c8e8", "Centipawn": None, "Mate": 2},
+        ]
+        moves = stockfish.get_top_moves(2, include_info=True)
+        assert all(
+            k in moves[0]
+            for k in (
+                "Move",
+                "Centipawn",
+                "Mate",
+                "MultiPVLine",
+                "N/s",
+                "Nodes",
+                "SelectiveDepth",
+                "Time",
+            )
+        )
+        if stockfish.does_current_engine_version_have_wdl_option():
+            assert "WDL" in moves[0]
+
     def test_get_top_moves_raising_error(self, stockfish):
         stockfish.set_fen_position(
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"


### PR DESCRIPTION
This PR combines and replaces https://github.com/py-stockfish/stockfish/pull/14 and https://github.com/py-stockfish/stockfish/pull/15 , with major refactor of `get_top_moves()` function. (It was much easier to combine the PR's, for obvious reasons.) I have left in quite a few comments in the refactor, to make it easier to follow. I will remove most of them once you've had a chance to look it over. 

- Refactor `get_top_moves()`, remove redundant code
- Add support for 'num_nodes', see #14
- Add support for 'verbose', see #15
- Add tests for new arguments
- Rename 'N/s' to 'NodesPerSecond'
- Add `turn_perspective` global option, defaults to _Turn_ perspective. (Note: this means that `get_top_moves()` will change from returning White perspective to returning Turn perspective by default, which is not backwards compatible. See https://github.com/py-stockfish/stockfish/issues/18)
- Add get/set for `self._turn_perspective`
- Add get/set for `self._num_nodes`
- Add `self._depth` as `int` and add public getter `get_depth()`. Fixes https://github.com/py-stockfish/stockfish/issues/8
- Add type checks for `set_depth()`, `set_num_nodes()`, `set_turn_perspective()` 
- Add more tests for instantiating `Stockfish` class
- Add test for `_set_option()`. Remove redundant default `update_parameters_attribute` arguments.
- Add convenience method `_pick()` to avoid doing `current_line[current_line.index("cp") + 1]`


Todo: Add `turn_perspective` option for rest of codebase, see https://github.com/py-stockfish/stockfish/issues/18
