### PR TITLE
Add python 3.11 to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
 )


### PR DESCRIPTION
In the 2 currently open PRs, the 3.11 tests were expected by github but couldn't run. This update to setup.py should fix that.

Edit - seems like this hasn't fixed the issue for those PRs.