### PR TITLE
Skip slow tests option

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,10 @@ stockfish.set_debug_view(True)
 ```bash
 $ python setup.py test
 ```
+To skip some of the slower tests, run:
+```bash
+$ python setup.py skip_slow_tests
+```
 
 ## Security
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,7 @@
 [tool:pytest]
 addopts = -ra -q --cov-report term-missing --cov-branch --cov-report xml --cov-report term
     --cov=stockfish -vv --strict-markers -rfE
-
-[aliases]
-test = pytest
+markers=slow
 
 testpaths =
     tests/stockfish/test_models.py

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import sys
 with open("README.md", "r") as readme:
     long_description = readme.read()
 
+
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -13,12 +14,15 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         import pytest
+
         sys.exit(pytest.main(self.test_args))
+
 
 class PyTestSkipSlow(PyTest):
     def finalize_options(self):
         super(PyTestSkipSlow, self).finalize_options()
-        self.test_args.append('-m not slow')
+        self.test_args.append("-m not slow")
+
 
 setup(
     name="stockfish",
@@ -51,5 +55,5 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-    cmdclass={'test': PyTest, 'skip_slow_tests': PyTestSkipSlow},
+    cmdclass={"test": PyTest, "skip_slow_tests": PyTestSkipSlow},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,24 @@
 from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
+import sys
 
 with open("README.md", "r") as readme:
     long_description = readme.read()
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        sys.exit(pytest.main(self.test_args))
+
+class PyTestSkipSlow(PyTest):
+    def finalize_options(self):
+        super(PyTestSkipSlow, self).finalize_options()
+        self.test_args.append('-m not slow')
 
 setup(
     name="stockfish",
@@ -34,4 +51,5 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
+    cmdclass={'test': PyTest, 'skip_slow_tests': PyTestSkipSlow},
 )

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -26,7 +26,7 @@ class Stockfish:
 
     def __init__(
         self,
-        path: str = "stockfish-engine",
+        path: str = "stockfish",
         depth: int = 15,
         parameters: Optional[dict] = None,
         num_nodes: int = 1000000,

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -26,7 +26,7 @@ class Stockfish:
 
     def __init__(
         self,
-        path: str = "stockfish",
+        path: str = "stockfish-engine",
         depth: int = 15,
         parameters: Optional[dict] = None,
         num_nodes: int = 1000000,

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -10,7 +10,7 @@ class TestStockfish:
     def stockfish(self):
         return Stockfish()
 
-    @pytest.mark.slow
+    # @pytest.mark.slow - example of how to use the marker
     def test_constructor_defaults(self):
         sf = Stockfish()
         assert sf is not None

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -10,7 +10,6 @@ class TestStockfish:
     def stockfish(self):
         return Stockfish()
 
-    # @pytest.mark.slow - example of how to use the marker
     def test_constructor_defaults(self):
         sf = Stockfish()
         assert sf is not None
@@ -55,6 +54,7 @@ class TestStockfish:
         best_move = stockfish.get_best_move_time(1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
+    @pytest.mark.slow
     def test_get_best_move_remaining_time_first_move(self, stockfish):
         best_move = stockfish.get_best_move(wtime=1000)
         assert best_move in ("a2a3", "d2d4", "e2e4", "g1f3", "c2c4")
@@ -82,6 +82,7 @@ class TestStockfish:
         best_move = stockfish.get_best_move_time(1000)
         assert best_move in ("d2d4", "g1f3")
 
+    @pytest.mark.slow
     def test_get_best_move_remaining_time_not_first_move(self, stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         best_move = stockfish.get_best_move(wtime=1000)
@@ -766,6 +767,7 @@ class TestStockfish:
             with pytest.raises(ValueError):
                 stockfish.make_moves_from_current_position([invalid_move])
 
+    @pytest.mark.slow
     def test_make_moves_transposition_table_speed(self, stockfish):
         """
         make_moves_from_current_position won't send the "ucinewgame" token to Stockfish, since it
@@ -838,12 +840,14 @@ class TestStockfish:
             with pytest.raises(RuntimeError):
                 stockfish.get_wdl_stats()
 
+    @pytest.mark.slow
     def test_benchmark_result_with_defaults(self, stockfish):
         params = stockfish.BenchmarkParameters()
         result = stockfish.benchmark(params)
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
 
+    @pytest.mark.slow
     def test_benchmark_result_with_valid_options(self, stockfish):
         params = stockfish.BenchmarkParameters(
             ttSize=64, threads=2, limit=1000, limitType="movetime", evalType="classical"
@@ -852,6 +856,7 @@ class TestStockfish:
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
 
+    @pytest.mark.slow
     def test_benchmark_result_with_invalid_options(self, stockfish):
         params = stockfish.BenchmarkParameters(
             ttSize=2049,
@@ -865,6 +870,7 @@ class TestStockfish:
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
 
+    @pytest.mark.slow
     def test_benchmark_result_with_invalid_type(self, stockfish):
         params = {
             "ttSize": 16,
@@ -1017,6 +1023,7 @@ class TestStockfish:
         with pytest.raises(ValueError):
             stockfish.will_move_be_a_capture("c3c5")
 
+    @pytest.mark.slow
     @pytest.mark.parametrize(
         "fen",
         [
@@ -1044,6 +1051,7 @@ class TestStockfish:
         with pytest.raises(StockfishException):
             stockfish.get_evaluation()
 
+    @pytest.mark.slow
     def test_is_fen_valid(self, stockfish):
         old_params = stockfish.get_engine_parameters()
         old_info = stockfish.info

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -10,6 +10,7 @@ class TestStockfish:
     def stockfish(self):
         return Stockfish()
 
+    @pytest.mark.slow
     def test_constructor_defaults(self):
         sf = Stockfish()
         assert sf is not None


### PR DESCRIPTION
This PR allows an additional testing command: "python setup.py skip_slow_tests". It will skip test functions in test_models.py that have a "@pytest.mark.slow" annotation (which we could add to any existing and future tests we want).

While it works fine, I seem to get a new deprecation warning instead of the old ones:

![image](https://github.com/py-stockfish/stockfish/assets/32089502/9ab6d2f0-d6b2-4553-96a3-d0fdf1d6245f)

For running the tests back on master:

![image](https://github.com/py-stockfish/stockfish/assets/32089502/2eb4afd4-e7e9-4750-9417-c50209ecd5ee)

Not entirely sure why this is.

@kieferro If you're familiar with this, do you think this is okay? Or is there a better way to implement what this PR is does.

Edit - as an aside, this PR increased the coverage report by over 2%, but I'm not sure what is being covered that wasn't before.