### PR TITLE
Functions for static evaluation and resuming full strength. Also updated docs and added warnings for weaker settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,8 @@ stockfish.get_static_eval()
 
 Sends the 'eval' command to Stockfish. This will get it to 'directly' evaluate the current position 
 (i.e., no search is involved), and output a float value (not a whole number centipawn).
-If one side is in check or mated, a static evaluation cannot be provided, and None will be returned.
+If one side is in check or mated, recent versions of Stockfish will output 'none' for the static eval.
+In this case, the function will return None.
 Some example return values:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ True
 
 ### Get info on the top n moves
 
-Get moves, centipawns, and mates for the top n moves. If the move is a mate, the Centipawn value will be None, and vice versa.
+Get moves, centipawns, and mates for the top n moves. If the move is a mate, the Centipawn value will be None, and vice versa. Note that if you have stockfish on a weaker elo or skill level setting, the top moves returned by this
+function will still be for full strength.
 
 ```python
 stockfish.get_top_moves(3)
@@ -243,6 +244,11 @@ stockfish.set_skill_level(15)
 
 ```python
 stockfish.set_elo_rating(1350)
+```
+
+### Put the engine back to full strength (if you've previously lowered the ELO or skill level)
+```python
+stockfish.resume_full_strength()
 ```
 
 ### Set the engine's depth
@@ -346,12 +352,13 @@ stockfish.get_board_visual(False)
   h   g   f   e   d   c   b   a
 ```
 
-### Get the current board evaluation in centipawns or mate in x
+### Get the current position's evaluation in centipawns or mate in x
 
 ```python
 stockfish.get_evaluation()
 ```
 
+Stockfish searches to the specified depth and evaluates the current position.
 A dictionary is returned representing the evaluation. Two example return values:
 
 ```text
@@ -362,6 +369,25 @@ A dictionary is returned representing the evaluation. Two example return values:
 
 If stockfish.get_turn_perspective() is True, then the eval value is relative to the side to move.
 Otherwise, positive is advantage white, negative is advantage black.
+
+### Get the current position's 'static evaluation'
+
+```python
+stockfish.get_static_eval()
+```
+
+Sends the 'eval' command to Stockfish. This will get it to 'directly' evaluate the current position 
+(i.e., no search is involved), and output a float value (not a whole number centipawn).
+If one side is in check or mated, a static evaluation cannot be provided, and None will be returned.
+Some example return values:
+
+```text
+-5.27
+
+0.28
+
+None
+```
 
 ### Run benchmark
 

--- a/README.md
+++ b/README.md
@@ -378,8 +378,10 @@ stockfish.get_static_eval()
 
 Sends the 'eval' command to Stockfish. This will get it to 'directly' evaluate the current position 
 (i.e., no search is involved), and output a float value (not a whole number centipawn).
+
 If one side is in check or mated, recent versions of Stockfish will output 'none' for the static eval.
 In this case, the function will return None.
+
 Some example return values:
 
 ```text

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -739,7 +739,9 @@ class Stockfish:
         self._put("eval")
         while True:
             text = self._read_line()
-            if text.startswith("Final evaluation"):
+            if text.startswith("Final evaluation") or text.startswith(
+                "Total Evaluation"
+            ):
                 splitted_text = text.split()
                 eval = splitted_text[2]
                 if eval == "none":

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -720,12 +720,12 @@ class Stockfish:
                 + """ get_evaluation will still return full strength Stockfish's evaluation of the position."""
             )
 
-        fen_position = self.get_fen_position()
-        compare = 1 if self.get_turn_perspective() or ("w" in fen_position) else -1
+        compare = (
+            1 if self.get_turn_perspective() or ("w" in self.get_fen_position()) else -1
+        )
         # If the user wants the evaluation specified relative to who is to move, this will be done.
         # Otherwise, the evaluation will be in terms of white's side (positive meaning advantage white,
         # negative meaning advantage black).
-        self._put(f"position {fen_position}")
         self._go()
         evaluation = dict()
         while True:
@@ -750,10 +750,12 @@ class Stockfish:
             in which case None is returned.
         """
 
-        fen_position = self.get_fen_position()
         # Stockfish gives the static eval from white's perspective:
-        compare = 1 if not self.get_turn_perspective() or ("w" in fen_position) else -1
-        self._put(f"position {fen_position}")
+        compare = (
+            1
+            if not self.get_turn_perspective() or ("w" in self.get_fen_position())
+            else -1
+        )
         self._put("eval")
         while True:
             text = self._read_line()

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -533,14 +533,14 @@ class TestStockfish:
 
     def test_get_static_eval(self, stockfish):
         stockfish.set_turn_perspective(False)
-        stockfish.set_fen_position("r7/8/8/8/8/4k3/4p3/4K3 w - - 0 1")
+        stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 w - - 0 1")
         assert stockfish.get_static_eval() < -3
         assert isinstance(stockfish.get_static_eval(), float)
-        stockfish.set_fen_position("r7/8/8/8/8/4k3/4p3/4K3 b - - 0 1")
+        stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 b - - 0 1")
         assert stockfish.get_static_eval() < -3
         stockfish.set_turn_perspective()
         assert stockfish.get_static_eval() > 3
-        stockfish.set_fen_position("r7/8/8/8/8/4k3/4p3/4K3 w - - 0 1")
+        stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 w - - 0 1")
         assert stockfish.get_static_eval() < -3
         stockfish.set_fen_position("8/8/8/8/8/4k3/4p3/r3K3 w - - 0 1")
         assert stockfish.get_static_eval() is None

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -542,8 +542,9 @@ class TestStockfish:
         assert stockfish.get_static_eval() > 3
         stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 w - - 0 1")
         assert stockfish.get_static_eval() < -3
-        stockfish.set_fen_position("8/8/8/8/8/4k3/4p3/r3K3 w - - 0 1")
-        assert stockfish.get_static_eval() is None
+        if stockfish.get_stockfish_major_version() >= 12:
+            stockfish.set_fen_position("8/8/8/8/8/4k3/4p3/r3K3 w - - 0 1")
+            assert stockfish.get_static_eval() is None
 
     def test_set_depth(self, stockfish):
         stockfish.set_depth(12)


### PR DESCRIPTION
- Resolves #35 by updating the documentation for get_top_moves, to note that full strength is used even if the user lowered elo or skill level. In addition, a warning is issued in get_top_moves, if the elo or skill level has been lowered.
- Continuing in the vein of the previous point, warnings are also issued in get_evaluation and get_wdl_stats, if the engine is on a weaker setting.
- Resolves #37 by adding a function to get the static evaluation. Also slightly updated the docs for get_evaluation to specify what is done in more detail.
- Added a function that allows the user to reset stockfish back to full strength, if they had previously lowered the elo or skill level.