### PR TITLE
Stuff related to parsing engine output

### DIFF
--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -567,19 +567,19 @@ class Stockfish:
         return self._get_best_move_from_sf_popen_process()
 
     def _get_best_move_from_sf_popen_process(self) -> Optional[str]:
-        """ Precondition - a "go" command must have been sent to SF before calling this function.
-            This function needs existing output to read from the SF popen process."""
+        """Precondition - a "go" command must have been sent to SF before calling this function.
+        This function needs existing output to read from the SF popen process."""
 
         lines: List[str] = self._get_sf_go_command_output()
         self.info = lines[-2]
         last_line_split = lines[-1].split(" ")
         return None if last_line_split[1] == "(none)" else last_line_split[1]
-    
+
     def _get_sf_go_command_output(self) -> List[str]:
-        """ Precondition - a "go" command must have been sent to SF before calling this function.
-            This function needs existing output to read from the SF popen process.
-            
-            A list of strings is returned, where each string represents a line of output. """
+        """Precondition - a "go" command must have been sent to SF before calling this function.
+        This function needs existing output to read from the SF popen process.
+
+        A list of strings is returned, where each string represents a line of output."""
 
         lines: List[str] = []
         while True:
@@ -687,7 +687,9 @@ class Stockfish:
             )
 
         self._go()
-        lines: List[List[str]] = [line.split(" ") for line in self._get_sf_go_command_output()]
+        lines: List[List[str]] = [
+            line.split(" ") for line in self._get_sf_go_command_output()
+        ]
         for current_line in reversed(lines):
             if current_line[0] == "bestmove" and current_line[1] == "(none)":
                 return None
@@ -842,8 +844,10 @@ class Stockfish:
         else:
             self._num_nodes = num_nodes
             self._go_nodes()
-        
-        lines: List[List[str]] = [line.split(" ") for line in self._get_sf_go_command_output()]
+
+        lines: List[List[str]] = [
+            line.split(" ") for line in self._get_sf_go_command_output()
+        ]
 
         # Stockfish is now done evaluating the position,
         # and the output is stored in the list 'lines'

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -762,11 +762,10 @@ class Stockfish:
         self._put("eval")
         while True:
             text = self._read_line()
-            if text.startswith("Final evaluation") or text.startswith(
-                "Total Evaluation"
+            if any(
+                text.startswith(x) for x in ("Final evaluation", "Total Evaluation")
             ):
-                splitted_text = text.split()
-                static_eval = splitted_text[2]
+                static_eval = text.split()[2]
                 if static_eval == "none":
                     assert "(in check)" in text
                     return None

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -764,7 +764,9 @@ class Stockfish:
                 text.startswith(x) for x in ("Final evaluation", "Total Evaluation")
             ):
                 static_eval = text.split()[2]
-                self._read_line()  # Consume the remaining line (for some reason `eval` outputs an extra newline)
+                if " none " not in text:
+                    self._read_line()
+                    # Consume the remaining line (for some reason `eval` outputs an extra newline)
                 if static_eval == "none":
                     assert "(in check)" in text
                     return None

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import subprocess
 from typing import Any, List, Optional, Union, Dict
 import copy
-from os import path
+import os
 from dataclasses import dataclass
 from enum import Enum
 import re
-from datetime import datetime
+import datetime
 import warnings
 
 
@@ -737,13 +737,13 @@ class Stockfish:
         # Otherwise, the evaluation will be in terms of white's side (positive meaning advantage white,
         # negative meaning advantage black).
         self._go()
-        evaluation: dict = dict()
+        evaluation: dict = {}
         while True:
             text = self._read_line()
             splitted_text = text.split(" ")
             if splitted_text[0] == "info":
-                for n in range(len(splitted_text)):
-                    if splitted_text[n] == "score":
+                for n, elem in enumerate(splitted_text):
+                    if elem == "score":
                         evaluation = {
                             "type": splitted_text[n + 1],
                             "value": int(splitted_text[n + 2]) * compare,
@@ -773,8 +773,8 @@ class Stockfish:
                 "Total Evaluation"
             ):
                 splitted_text = text.split()
-                eval = splitted_text[2]
-                if eval == "none":
+                static_eval = splitted_text[2]
+                if static_eval == "none":
                     assert "(in check)" in text
                     return None
                 else:
@@ -1110,11 +1110,11 @@ class Stockfish:
         self, date_string: str = ""
     ) -> Optional[str]:
         # Convert date string to datetime object
-        date_object = datetime.strptime(date_string, "%Y-%m-%d")
+        date_object = datetime.datetime.strptime(date_string, "%Y-%m-%d")
 
         # Convert release date strings to datetime objects
         releases_datetime = {
-            key: datetime.strptime(value, "%Y-%m-%d")
+            key: datetime.datetime.strptime(value, "%Y-%m-%d")
             for key, value in self._releases.items()
         }
 
@@ -1179,7 +1179,7 @@ class Stockfish:
             self.limit = self.limit if self.limit in range(1, 10001) else 13
             self.fenFile = (
                 self.fenFile
-                if self.fenFile.endswith(".fen") and path.isfile(self.fenFile)
+                if self.fenFile.endswith(".fen") and os.path.isfile(self.fenFile)
                 else "default"
             )
             self.limitType = (

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -690,10 +690,10 @@ class Stockfish:
             )
 
         self._go()
-        lines = list(reversed(self._get_sf_go_command_output()))
-        if lines[0].startswith("bestmove (none)"):
+        lines = self._get_sf_go_command_output()
+        if lines[-1].startswith("bestmove (none)"):
             return None
-        split_line = next(line.split(" ") for line in lines if " multipv 1 " in line)
+        split_line = [line.split(" ") for line in lines if " multipv 1 " in line][-1]
         wdl_index = split_line.index("wdl")
         return [int(split_line[i]) for i in range(wdl_index + 1, wdl_index + 4)]
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -736,8 +736,8 @@ class Stockfish:
         # Otherwise, the evaluation will be in terms of white's side (positive meaning advantage white,
         # negative meaning advantage black).
         self._go()
-        lines = list(reversed(self._get_sf_go_command_output()))
-        split_line = next(line.split(" ") for line in lines if line.startswith("info"))
+        lines = self._get_sf_go_command_output()
+        split_line = [line.split(" ") for line in lines if line.startswith("info")][-1]
         score_index = split_line.index("score")
         eval_type, val = split_line[score_index + 1], split_line[score_index + 2]
         return {"type": eval_type, "value": int(val) * compare}

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -691,7 +691,7 @@ class Stockfish:
         lines = list(reversed(self._get_sf_go_command_output()))
         if lines[0].startswith("bestmove (none)"):
             return None
-        split_line = next(line.split(" ") for line in lines if ' multipv 1 ' in line)
+        split_line = next(line.split(" ") for line in lines if " multipv 1 " in line)
         wdl_index = split_line.index("wdl")
         return [int(split_line[i]) for i in range(wdl_index + 1, wdl_index + 4)]
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -786,12 +786,14 @@ class TestStockfish:
         assert stockfish.get_turn_perspective()
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] > 0
-        assert isinstance(eval := stockfish.get_evaluation()["value"], int) and eval > 0  # type: ignore
+        eval = stockfish.get_evaluation()["value"]
+        assert isinstance(eval, int) and eval > 0
         stockfish.set_turn_perspective(False)
         assert stockfish.get_turn_perspective() is False
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] < 0
-        assert isinstance(eval := stockfish.get_evaluation()["value"], int) and eval < 0
+        eval = stockfish.get_evaluation()["value"]
+        assert isinstance(eval, int) and eval < 0
 
     def test_turn_perspective_raises_type_error(self, stockfish: Stockfish):
         with pytest.raises(TypeError):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -565,7 +565,7 @@ class TestStockfish:
             assert stockfish.get_static_eval() is None
         stockfish.set_position(None)
         stockfish.get_static_eval()
-        stockfish._put('go depth 2')
+        stockfish._put("go depth 2")
         assert stockfish._read_line() != ""
 
     def test_set_depth(self, stockfish: Stockfish):
@@ -786,7 +786,7 @@ class TestStockfish:
         assert stockfish.get_turn_perspective()
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] > 0
-        assert isinstance(eval := stockfish.get_evaluation()["value"], int) and eval > 0
+        assert isinstance(eval := stockfish.get_evaluation()["value"], int) and eval > 0  # type: ignore
         stockfish.set_turn_perspective(False)
         assert stockfish.get_turn_perspective() is False
         moves = stockfish.get_top_moves(1)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1,7 +1,6 @@
 import pytest
 from timeit import default_timer
 import time
-import warnings
 
 from stockfish import Stockfish, StockfishException
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -556,6 +556,10 @@ class TestStockfish:
         if stockfish.get_stockfish_major_version() >= 12:
             stockfish.set_fen_position("8/8/8/8/8/4k3/4p3/r3K3 w - - 0 1")
             assert stockfish.get_static_eval() is None
+        stockfish.set_position(None)
+        stockfish.get_static_eval()
+        stockfish._put('go depth 2')
+        assert stockfish._read_line() != ""
 
     def test_set_depth(self, stockfish: Stockfish):
         stockfish.set_depth(12)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -10,6 +10,13 @@ class TestStockfish:
     def stockfish(self) -> Stockfish:
         return Stockfish()
 
+    # change to `autouse=True` to have the below fixture called before each test function, and then
+    # the code after the 'yield' to run after each test.
+    @pytest.fixture(autouse=False)
+    def autouse_fixture(self, stockfish: Stockfish):
+        yield stockfish
+        # Some assert statement testing something about the stockfish object here.
+
     def test_constructor_defaults(self):
         sf = Stockfish()
         assert sf is not None

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -515,6 +515,7 @@ class TestStockfish:
         evaluation = stockfish.get_evaluation()
         assert (
             evaluation["type"] == "cp"
+            and isinstance(evaluation["value"], int)
             and evaluation["value"] >= 60
             and evaluation["value"] <= 150
         )
@@ -523,6 +524,7 @@ class TestStockfish:
             evaluation = stockfish.get_evaluation()
         assert (
             evaluation["type"] == "cp"
+            and isinstance(evaluation["value"], int)
             and evaluation["value"] >= 60
             and evaluation["value"] <= 150
         )
@@ -773,12 +775,12 @@ class TestStockfish:
         assert stockfish.get_turn_perspective()
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] > 0
-        assert stockfish.get_evaluation()["value"] > 0
+        assert isinstance(eval := stockfish.get_evaluation()["value"], int) and eval > 0
         stockfish.set_turn_perspective(False)
         assert stockfish.get_turn_perspective() is False
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] < 0
-        assert stockfish.get_evaluation()["value"] < 0
+        assert isinstance(eval := stockfish.get_evaluation()["value"], int) and eval < 0
 
     def test_turn_perspective_raises_type_error(self, stockfish: Stockfish):
         with pytest.raises(TypeError):


### PR DESCRIPTION
- Adds a private function to read SF output (after a `go` command), and return it as a list of strings.
- Updates the `get_wdl_stats`, `get_evaluation`, and `get_top_moves` functions to use it. Some cleanup is done in these functions to make the code a little more concise.
- In `get_static_eval` and `_parse_stockfish_version`, ensure all of the stockfish engine's stdout output is discarded, after calling `_read_lines`.