### PR TITLE
Add tuple return type

### DIFF
--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -706,11 +706,16 @@ class Stockfish:
         self.info = old_self_info
         return is_move_correct
 
-    def get_wdl_stats(self) -> Optional[List[int]]:
+    def get_wdl_stats(self, get_as_tuple: bool = False) -> Union[List[int], Tuple[int, int, int], None]:
         """Returns Stockfish's win/draw/loss stats for the side to move.
 
+        Args:
+            get_as_tuple:
+                Option to return the wdl stats as a tuple instead of a list
+                `Boolean`. Default is `False`.
+        
         Returns:
-            A list of three integers, unless the game is over (in which case
+            A list or tuple of three integers, unless the game is over (in which case
             `None` is returned).
         """
 
@@ -730,6 +735,9 @@ class Stockfish:
             return None
         split_line = [line.split(" ") for line in lines if " multipv 1 " in line][-1]
         wdl_index = split_line.index("wdl")
+
+        if get_as_tuple:
+            return tuple([int(split_line[i]) for i in range(wdl_index + 1, wdl_index + 4)])
         return [int(split_line[i]) for i in range(wdl_index + 1, wdl_index + 4)]
 
     def does_current_engine_version_have_wdl_option(self) -> bool:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -708,7 +708,7 @@ class Stockfish:
 
     def get_wdl_stats(
         self, get_as_tuple: bool = False
-    ) -> Union[list[int] | tuple[int, ...] | None]:
+    ) -> Union[list[int] | tuple[int, int, int] | None]:
         """Returns Stockfish's win/draw/loss stats for the side to move.
 
         Args:
@@ -741,7 +741,7 @@ class Stockfish:
         wdl_stats = [int(split_line[i]) for i in range(wdl_index + 1, wdl_index + 4)]
 
         if get_as_tuple:
-            return tuple(wdl_stats)
+            return (wdl_stats[0], wdl_stats[1], wdl_stats[2])
         return wdl_stats
 
     def does_current_engine_version_have_wdl_option(self) -> bool:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -706,14 +706,16 @@ class Stockfish:
         self.info = old_self_info
         return is_move_correct
 
-    def get_wdl_stats(self, get_as_tuple: bool = False) -> Union[List[int], Tuple[int, int, int], None]:
+    def get_wdl_stats(
+        self, get_as_tuple: bool = False
+    ) -> Union[list[int] | tuple[int, ...] | None]:
         """Returns Stockfish's win/draw/loss stats for the side to move.
 
         Args:
             get_as_tuple:
                 Option to return the wdl stats as a tuple instead of a list
                 `Boolean`. Default is `False`.
-        
+
         Returns:
             A list or tuple of three integers, unless the game is over (in which case
             `None` is returned).
@@ -736,9 +738,11 @@ class Stockfish:
         split_line = [line.split(" ") for line in lines if " multipv 1 " in line][-1]
         wdl_index = split_line.index("wdl")
 
+        wdl_stats = [int(split_line[i]) for i in range(wdl_index + 1, wdl_index + 4)]
+
         if get_as_tuple:
-            return tuple([int(split_line[i]) for i in range(wdl_index + 1, wdl_index + 4)])
-        return [int(split_line[i]) for i in range(wdl_index + 1, wdl_index + 4)]
+            return tuple(wdl_stats)
+        return wdl_stats
 
     def does_current_engine_version_have_wdl_option(self) -> bool:
         """Returns whether the user's version of Stockfish has the option
@@ -923,13 +927,15 @@ class Stockfish:
                 # get move
                 "Move": self._pick(line, "pv"),
                 # get cp if available
-                "Centipawn": int(self._pick(line, "cp")) * perspective
-                if "cp" in line
-                else None,
+                "Centipawn": (
+                    int(self._pick(line, "cp")) * perspective if "cp" in line else None
+                ),
                 # get mate if available
-                "Mate": int(self._pick(line, "mate")) * perspective
-                if "mate" in line
-                else None,
+                "Mate": (
+                    int(self._pick(line, "mate")) * perspective
+                    if "mate" in line
+                    else None
+                ),
             }
 
             # add more info if verbose

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -914,6 +914,9 @@ class TestStockfish:
             wdl_stats_3 = stockfish.get_wdl_stats()
             assert isinstance(wdl_stats_3, list) and len(wdl_stats_3) == 3
 
+            wdl_stats_4 = stockfish.get_wdl_stats(get_as_tuple=True)
+            assert isinstance(wdl_stats_4, tuple) and len(wdl_stats_4) == 3
+
             stockfish.set_fen_position("8/8/8/8/8/3k4/3p4/3K4 w - - 0 1")
             assert stockfish.get_wdl_stats() is None
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -916,6 +916,8 @@ class TestStockfish:
 
             wdl_stats_4 = stockfish.get_wdl_stats(get_as_tuple=True)
             assert isinstance(wdl_stats_4, tuple) and len(wdl_stats_4) == 3
+            assert wdl_stats_3 == list(wdl_stats_4)
+            assert tuple(wdl_stats_3) == wdl_stats_4
 
             stockfish.set_fen_position("8/8/8/8/8/3k4/3p4/3K4 w - - 0 1")
             assert stockfish.get_wdl_stats() is None


### PR DESCRIPTION
Add tuple as a return type to get_wdl_stats.
Add one test to ensure return type is a tuple when argument get_as_tuple=True.
Closes issue #46.