### PR TITLE
Update the gitignore and readme to aid contributing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@
 !*/
 !LICENSE
 
-/*.exe
+*.exe
 /Notes/
+/stockfish/main.py
 
 .DS_Store
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,6 @@
 /.idea/
 /.eggs/
 /stockfish.egg-info/
-/.mypy_cache/
-/.pytest_cache/
-__pycache/
 /build/
 /dist/
 /venv/

--- a/README.md
+++ b/README.md
@@ -534,16 +534,6 @@ You can (de-)activate the debug view option with the `set_debug_view` function. 
 stockfish.set_debug_view(True)
 ```
 
-## Testing
-
-```bash
-$ python setup.py test
-```
-To skip some of the slower tests, run:
-```bash
-$ python setup.py skip_slow_tests
-```
-
 ## Contributing
 
 Most contributions will involve making updates to `stockfish/models.py`. To test your changes, download a version of stockfish and paste the executable in the `stockfish` folder. Then, create a file in the `stockfish` folder called `main.py`. Both the executable and `main.py` will be ignored by git.
@@ -560,6 +550,26 @@ if __name__ == "__main__":
     main()
 ```
 Then when navigating to the `stockfish` folder in the terminal, you can run this `main.py` file simply with `python main.py`.
+Once you're satisfied with your changes to `models.py`, see the section below for how to run the project's entire test suite.
+
+## Testing
+
+For your stockfish executable (the same one mentioned in the previous section), paste it also in the project's root directory. Then in `models.py`,
+temporarily modify this line so that the `path`'s default value is changed from "stockfish" to the name of your stockfish executable:
+
+```python
+path: str = "stockfish",
+```
+
+Then in the project's root directory, you can run:
+
+```bash
+$ python setup.py test
+```
+To skip some of the slower tests, run:
+```bash
+$ python setup.py skip_slow_tests
+```
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -544,6 +544,23 @@ To skip some of the slower tests, run:
 $ python setup.py skip_slow_tests
 ```
 
+## Contributing
+
+Most contributions will involve making updates to `stockfish/models.py`. To test your changes, download a version of stockfish and paste the executable in the `stockfish` folder. Then, create a file in the `stockfish` folder called `main.py`. Both the executable and `main.py` will be ignored by git.
+In `main.py`, start with something like the following:
+
+```python
+from models import Stockfish
+
+def main():
+    sf = Stockfish(path = "name of your stockfish executable")
+    # Use this object as you wish to test your changes.
+
+if __name__ == "__main__":
+    main()
+```
+Then when navigating to the `stockfish` folder in the terminal, you can run this `main.py` file simply with `python main.py`.
+
 ## Security
 
 If you discover any security related issues, please report it via the [Private vulnerability reporting](https://github.com/py-stockfish/stockfish/security) instead of using the issue tracker.

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Before calling this function, it is recommended that you first check if your ver
 use the "does_current_engine_version_have_wdl_option()" function below.
 
 ```python
-stockfish.get_wdl_stats()
+stockfish.get_wdl_stats() # include the argument get_as_tuple=True if you'd like to have a tuple returned instead of a list.
 ```
 
 ```text

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -706,9 +706,7 @@ class Stockfish:
         self.info = old_self_info
         return is_move_correct
 
-    def get_wdl_stats(
-        self, get_as_tuple: bool = False
-    ) -> Union[list[int] | tuple[int, int, int] | None]:
+    def get_wdl_stats(self, get_as_tuple: bool = False) -> list[int] | tuple[int, int, int] | None:
         """Returns Stockfish's win/draw/loss stats for the side to move.
 
         Args:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -915,13 +915,15 @@ class Stockfish:
                 # get move
                 "Move": self._pick(line, "pv"),
                 # get cp if available
-                "Centipawn": int(self._pick(line, "cp")) * perspective
-                if "cp" in line
-                else None,
+                "Centipawn": (
+                    int(self._pick(line, "cp")) * perspective if "cp" in line else None
+                ),
                 # get mate if available
-                "Mate": int(self._pick(line, "mate")) * perspective
-                if "mate" in line
-                else None,
+                "Mate": (
+                    int(self._pick(line, "mate")) * perspective
+                    if "mate" in line
+                    else None
+                ),
             }
 
             # add more info if verbose

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -914,6 +914,7 @@ class TestStockfish:
             wdl_stats_3 = stockfish.get_wdl_stats()
             assert isinstance(wdl_stats_3, list) and len(wdl_stats_3) == 3
 
+            stockfish._prepare_for_new_position()
             wdl_stats_4 = stockfish.get_wdl_stats(get_as_tuple=True)
             assert isinstance(wdl_stats_4, tuple) and len(wdl_stats_4) == 3
             assert wdl_stats_3 == list(wdl_stats_4)


### PR DESCRIPTION
This PR adds some tips to the readme on how contributors can test their changes made to `stockfish/models.py`. The gitignore is also updated so that executables and a `main.py` file are ignored in the `stockfish` folder. Minor updates to some `get_wdl_stats` stuff is also done.