### PR TITLE
Add `--binary-path` option for tests

### DIFF
--- a/tests/stockfish/conftest.py
+++ b/tests/stockfish/conftest.py
@@ -3,7 +3,9 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption("--binary-path", action="store", default=None, help="Path to the binary")
+    parser.addoption(
+        "--binary-path", action="store", default=None, help="Path to the binary"
+    )
 
 
 @pytest.fixture

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -590,7 +590,8 @@ class TestStockfish:
 
         stockfish_2 = Stockfish(
             path=binary_path,
-            depth=16, parameters={"MultiPV": 2, "UCI_Elo": 2850, "UCI_Chess960": True}
+            depth=16,
+            parameters={"MultiPV": 2, "UCI_Elo": 2850, "UCI_Chess960": True},
         )
         assert (
             stockfish_2.get_fen_position()


### PR DESCRIPTION
As mentioned in the [issue](https://github.com/py-stockfish/stockfish/issues/72) now you need to have SF binary callable as `stockfish`.

Here a fixture with three options to provide path to binary:
* command line parameter `--binary-path`
* environmental variable `TEST_STOCKFISH_BINARY`
* default value `stockfish`