### PR TITLE
Don't do the `ucinewgame` command by default

### DIFF
--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -208,7 +208,7 @@ class Stockfish:
         """
         self.update_engine_parameters(self._DEFAULT_STOCKFISH_PARAMS)
 
-    def _prepare_for_new_position(self, send_ucinewgame_token: bool = True) -> None:
+    def _prepare_for_new_position(self, send_ucinewgame_token: bool) -> None:
         if send_ucinewgame_token:
             self._put("ucinewgame")
         self._is_ready()

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -299,7 +299,7 @@ class Stockfish:
         warnings.warn(message, stacklevel=3)
 
     def set_fen_position(
-        self, fen_position: str, send_ucinewgame_token: bool = True
+        self, fen_position: str, send_ucinewgame_token: bool = False
     ) -> None:
         """Sets current board position in Forsyth-Edwards notation (FEN).
 
@@ -309,8 +309,8 @@ class Stockfish:
 
             send_ucinewgame_token:
               Whether to send the `ucinewgame` token to the Stockfish engine.
-              The most prominent effect this will have is clearing Stockfish's transposition table,
-              which should be done if the new position is unrelated to the current position.
+              This will clear Stockfish's hash table, which should generally only be done if the new
+              position is unrelated to the current one (such as a new game).
 
         Returns:
             `None`

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -127,23 +127,25 @@ class TestStockfish:
         assert stockfish.info == "info depth 0 score mate 0"
 
     def test_clear_info_after_set_new_fen_position(self, stockfish: Stockfish):
-        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/r7/4K3 b - - 11 52")
+        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/r7/4K3 b - - 11 52", True)
         stockfish.get_best_move()
-        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53")
+        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53", True)
         assert stockfish.info == ""
 
-        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/r7/4K3 b - - 11 52")
+        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/r7/4K3 b - - 11 52", True)
         stockfish.get_best_move()
         stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53", False)
         assert stockfish.info == ""
 
     def test_set_fen_position_starts_new_game(self, stockfish: Stockfish):
         stockfish.set_fen_position(
-            "7r/1pr1kppb/2n1p2p/2NpP2P/5PP1/1P6/P6K/R1R2B2 w - - 1 27"
+            "7r/1pr1kppb/2n1p2p/2NpP2P/5PP1/1P6/P6K/R1R2B2 w - - 1 27", True
         )
         stockfish.get_best_move()
         assert stockfish.info != ""
-        stockfish.set_fen_position("3kn3/p5rp/1p3p2/3B4/3P1P2/2P5/1P3K2/8 w - - 0 53")
+        stockfish.set_fen_position(
+            "3kn3/p5rp/1p3p2/3B4/3P1P2/2P5/1P3K2/8 w - - 0 53", True
+        )
         assert stockfish.info == ""
 
     def test_set_fen_position_second_argument(self, stockfish: Stockfish):
@@ -182,7 +184,9 @@ class TestStockfish:
     )
     # fmt: on
     def test_last_info(self, stockfish: Stockfish, value):
-        stockfish.set_fen_position("r6k/6b1/2b1Q3/p6p/1p5q/3P2PP/5r1K/8 w - - 1 31")
+        stockfish.set_fen_position(
+            "r6k/6b1/2b1Q3/p6p/1p5q/3P2PP/5r1K/8 w - - 1 31", True
+        )
         stockfish.get_best_move()
         assert value in stockfish.info
 
@@ -516,20 +520,20 @@ class TestStockfish:
 
     def test_get_static_eval(self, stockfish: Stockfish):
         stockfish.set_turn_perspective(False)
-        stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 w - - 0 1")
+        stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 w - - 0 1", True)
         static_eval_1 = stockfish.get_static_eval()
         assert isinstance(static_eval_1, float) and static_eval_1 < -3
-        stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 b - - 0 1")
+        stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 b - - 0 1", True)
         static_eval_2 = stockfish.get_static_eval()
         assert isinstance(static_eval_2, float) and static_eval_2 < -3
         stockfish.set_turn_perspective()
         static_eval_3 = stockfish.get_static_eval()
         assert isinstance(static_eval_3, float) and static_eval_3 > 3
-        stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 w - - 0 1")
+        stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 w - - 0 1", True)
         static_eval_4 = stockfish.get_static_eval()
         assert isinstance(static_eval_4, float) and static_eval_4 < -3
         if stockfish.get_stockfish_major_version() >= 12:
-            stockfish.set_fen_position("8/8/8/8/8/4k3/4p3/r3K3 w - - 0 1")
+            stockfish.set_fen_position("8/8/8/8/8/4k3/4p3/r3K3 w - - 0 1", True)
             assert stockfish.get_static_eval() is None
         stockfish.set_position(None)
         stockfish.get_static_eval()
@@ -879,7 +883,7 @@ class TestStockfish:
 
         total_time_calculating_second = 0.0
         for i in range(len(positions_considered)):
-            stockfish.set_fen_position(positions_considered[i])
+            stockfish.set_fen_position(positions_considered[i], True)
             start = default_timer()
             stockfish.get_best_move()
             total_time_calculating_second += default_timer() - start
@@ -898,7 +902,7 @@ class TestStockfish:
             assert abs(wdl_stats[0] - wdl_stats[2]) / wdl_stats[0] < 0.15
 
             stockfish.set_fen_position(
-                "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+                "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", True
             )
             wdl_stats_2 = stockfish.get_wdl_stats()
             assert isinstance(wdl_stats_2, list)
@@ -909,7 +913,8 @@ class TestStockfish:
             assert stockfish.get_wdl_stats() is None
 
             stockfish.set_fen_position(
-                "rnbqkb1r/pp3ppp/3p1n2/1B2p3/3NP3/2N5/PPP2PPP/R1BQK2R b KQkq - 0 6"
+                "rnbqkb1r/pp3ppp/3p1n2/1B2p3/3NP3/2N5/PPP2PPP/R1BQK2R b KQkq - 0 6",
+                True,
             )
             wdl_stats_3 = stockfish.get_wdl_stats()
             assert isinstance(wdl_stats_3, list) and len(wdl_stats_3) == 3

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -919,7 +919,7 @@ class TestStockfish:
             wdl_stats_3 = stockfish.get_wdl_stats()
             assert isinstance(wdl_stats_3, list) and len(wdl_stats_3) == 3
 
-            stockfish._prepare_for_new_position()
+            stockfish._prepare_for_new_position(True)
             wdl_stats_4 = stockfish.get_wdl_stats(get_as_tuple=True)
             assert isinstance(wdl_stats_4, tuple) and len(wdl_stats_4) == 3
             assert wdl_stats_3 == list(wdl_stats_4)


### PR DESCRIPTION
Closes #77.

As explained by the author of Fairy Stockfish [here](https://chess.stackexchange.com/a/26635/12873): "In fact, in Stockfish [ucinewgame](https://github.com/official-stockfish/Stockfish/blob/80d59eea392fc073f6d0ba29cb9a97e3d705ee58/src/uci.cpp#L229) does exactly the same as [setoption name Clear Hash](https://github.com/official-stockfish/Stockfish/blob/80d59eea392fc073f6d0ba29cb9a97e3d705ee58/src/ucioption.cpp#L40)".

For users, clearing the hash wouldn't be good to do when making moves, as it'll slow down a subsequent search. Also, clearing the table takes time itself. It only makes sense when starting a new game, but even then I suspect Stockfish's algorithm would clear it as it sees fit.