### PR TITLE
Fix `is_move_correct` and `get_perft` for newer versions of Stockfish.

### DIFF
--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -5,6 +5,7 @@ Copyright (c) 2016-2025 by Ilya Zhelyabuzhsky and contributors.
 Contributors: https://github.com/py-stockfish/stockfish/graphs/contributors
 License: MIT. See LICENSE for more details.
 """
+
 from __future__ import annotations
 import subprocess
 from typing import Any
@@ -681,11 +682,7 @@ class Stockfish:
         Example:
             >>> is_correct = stockfish.is_move_correct("f4f5")
         """
-        old_self_info = self.info
-        self._put(f"go depth 1 searchmoves {move_value}")
-        is_move_correct = self._get_best_move_from_sf_popen_process() is not None
-        self.info = old_self_info
-        return is_move_correct
+        return move_value in self.get_perft(1)[1]
 
     def get_wdl_stats(
         self, get_as_tuple: bool = False
@@ -967,14 +964,16 @@ class Stockfish:
 
         while True:
             line = self._read_line()
-            if line == "":
+            if line == "" or line.startswith("info"):
                 continue
             if "searched" in line:
                 num_nodes = int(line.split(":")[1])
                 break
             move, num = line.split(":")
             if move in move_possibilities:
-                raise RuntimeError()
+                raise RuntimeError(
+                    "If you're playing chess960, make sure to set `UCI_Chess960` to `true`!"
+                )
             move_possibilities[move] = int(num)
         self._read_line()  # Consumes the remaining newline stockfish outputs.
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -359,6 +359,7 @@ class TestStockfish:
         assert (
             stockfish.will_move_be_a_capture("f1e1") is Stockfish.Capture.DIRECT_CAPTURE
         )
+        assert stockfish.get_perft(1)[0] == 13
         stockfish.update_engine_parameters({"UCI_Chess960": False})
         assert stockfish.get_engine_parameters() == old_parameters
         assert stockfish.get_best_move() == "f1g1"
@@ -366,7 +367,10 @@ class TestStockfish:
         assert stockfish.get_evaluation() == {"type": "mate", "value": 2}
         stockfish.set_turn_perspective()
         assert stockfish.get_evaluation() == {"type": "mate", "value": 2}
-        assert stockfish.will_move_be_a_capture("f1g1") is Stockfish.Capture.NO_CAPTURE
+        with pytest.raises(RuntimeError):
+            stockfish.is_move_correct("f1g1")
+        with pytest.raises(RuntimeError):
+            stockfish.get_perft(1)
 
     def test_get_board_visual_white(self, stockfish: Stockfish):
         stockfish.make_moves_from_start(["e2e4", "e7e6", "d2d4", "d7d5"])


### PR DESCRIPTION
Closes #128